### PR TITLE
Add world clock map page and navigation link

### DIFF
--- a/src/components/page/Header.vue
+++ b/src/components/page/Header.vue
@@ -22,6 +22,9 @@
                 <v-btn id="historyBtn" text link to="/medals">
                     {{ $t('Home.medalsBtn') }}
                 </v-btn>
+                <v-btn id="worldClockBtn" text link to="/world-clock">
+                    {{ $t('Home.worldClockBtn') }}
+                </v-btn>
                 <div class="header__nav__btns">
                     <v-btn id="aboutBtn" icon @click="aboutDialog = true">
                         <v-icon size="30"> mdi-help-circle </v-icon>

--- a/src/lang/locale/ar.json
+++ b/src/lang/locale/ar.json
@@ -50,7 +50,8 @@
       "mapsTitle": "الخرائط",
       "pleaseSelectLabel": "يبدو أنك فقدت، الرجاء تحديد نوع أو يمكنك ",
       "barrelRoll": "اصنع لوح البرميل"
-    }
+    },
+    "worldClockBtn": "WORLD CLOCK"
   },
   "StreetView": {
     "nearby": {
@@ -218,5 +219,13 @@
   "AlertUpdate": {
     "label": "يتوفر إصدار جديد. انقر على الزر للحصول عليه.",
     "btn": "تحديث"
+  },
+  "WorldClock": {
+    "title": "World clock & map",
+    "subtitle": "See the current time across major capitals with an interactive map overlay.",
+    "updatedInRealTime": "Times refresh every second to stay accurate.",
+    "mapCaption": "Hover each pin to see the local time and city name.",
+    "listTitle": "Major capitals",
+    "timezoneLabel": "Timezone"
   }
 }

--- a/src/lang/locale/bg.json
+++ b/src/lang/locale/bg.json
@@ -50,7 +50,8 @@
       "mapsTitle": "Maps",
       "pleaseSelectLabel": "You seems lost, please select a type or you can ",
       "barrelRoll": "do a barrel roll"
-    }
+    },
+    "worldClockBtn": "WORLD CLOCK"
   },
   "StreetView": {
     "nearby": {
@@ -218,5 +219,13 @@
   "AlertUpdate": {
     "label": "A new version is available. Click on the button to obtain it.",
     "btn": "Update"
+  },
+  "WorldClock": {
+    "title": "World clock & map",
+    "subtitle": "See the current time across major capitals with an interactive map overlay.",
+    "updatedInRealTime": "Times refresh every second to stay accurate.",
+    "mapCaption": "Hover each pin to see the local time and city name.",
+    "listTitle": "Major capitals",
+    "timezoneLabel": "Timezone"
   }
 }

--- a/src/lang/locale/cs.json
+++ b/src/lang/locale/cs.json
@@ -50,7 +50,8 @@
       "mapsTitle": "Maps",
       "pleaseSelectLabel": "You seems lost, please select a type or you can ",
       "barrelRoll": "do a barrel roll"
-    }
+    },
+    "worldClockBtn": "WORLD CLOCK"
   },
   "StreetView": {
     "nearby": {
@@ -218,5 +219,13 @@
   "AlertUpdate": {
     "label": "Nová verze je dostupná, klikněte na tlačítko pro její získání.",
     "btn": "Aktualizovat"
+  },
+  "WorldClock": {
+    "title": "World clock & map",
+    "subtitle": "See the current time across major capitals with an interactive map overlay.",
+    "updatedInRealTime": "Times refresh every second to stay accurate.",
+    "mapCaption": "Hover each pin to see the local time and city name.",
+    "listTitle": "Major capitals",
+    "timezoneLabel": "Timezone"
   }
 }

--- a/src/lang/locale/de.json
+++ b/src/lang/locale/de.json
@@ -50,7 +50,8 @@
       "mapsTitle": "Maps",
       "pleaseSelectLabel": "Sie scheinen verloren zu sein, bitte wählen Sie einen Typ oder Sie können ",
       "barrelRoll": "mache eine Fassrolle"
-    }
+    },
+    "worldClockBtn": "WORLD CLOCK"
   },
   "StreetView": {
     "nearby": {
@@ -218,5 +219,13 @@
   "AlertUpdate": {
     "label": "Eine neue Version ist verfügbar. Klicke auf die Schaltfläche, um sie zu installieren.",
     "btn": "Update"
+  },
+  "WorldClock": {
+    "title": "World clock & map",
+    "subtitle": "See the current time across major capitals with an interactive map overlay.",
+    "updatedInRealTime": "Times refresh every second to stay accurate.",
+    "mapCaption": "Hover each pin to see the local time and city name.",
+    "listTitle": "Major capitals",
+    "timezoneLabel": "Timezone"
   }
 }

--- a/src/lang/locale/en.json
+++ b/src/lang/locale/en.json
@@ -50,7 +50,8 @@
       "mapsTitle": "Maps",
       "pleaseSelectLabel": "You seems lost, please select a type or you can ",
       "barrelRoll": "do a barrel roll"
-    }
+    },
+    "worldClockBtn": "WORLD CLOCK"
   },
   "StreetView": {
     "nearby": {
@@ -169,8 +170,8 @@
     "allowMove": "Allow Move",
     "allowZoom": "Allow Zoom",
     "allowPan": "Allow Pan",
-    "guessedLeaderboard" : "Display whether players have guessed",
-    "scoreLeaderboard" : "Display score leaderboard",
+    "guessedLeaderboard": "Display whether players have guessed",
+    "scoreLeaderboard": "Display score leaderboard",
     "countDownLabel": "CountDown (seconds)",
     "scoreModeLabel": "Score formula",
     "scoreModes": {
@@ -218,5 +219,13 @@
   "AlertUpdate": {
     "label": "A new version is available. Click on the button to obtain it.",
     "btn": "Update"
+  },
+  "WorldClock": {
+    "title": "World clock & map",
+    "subtitle": "See the current time across major capitals with an interactive map overlay.",
+    "updatedInRealTime": "Times refresh every second to stay accurate.",
+    "mapCaption": "Hover each pin to see the local time and city name.",
+    "listTitle": "Major capitals",
+    "timezoneLabel": "Timezone"
   }
 }

--- a/src/lang/locale/es.json
+++ b/src/lang/locale/es.json
@@ -50,7 +50,8 @@
       "mapsTitle": "Mapas",
       "pleaseSelectLabel": "Pareces perdido, por favor, selecciona un tipo o puedes ",
       "barrelRoll": "hacer una vuelta de barril"
-    }
+    },
+    "worldClockBtn": "WORLD CLOCK"
   },
   "StreetView": {
     "nearby": {
@@ -218,5 +219,13 @@
   "AlertUpdate": {
     "label": "Hay disponible una nueva versión. Haga clic en el botón para obtenerla.",
     "btn": "Actualizar"
+  },
+  "WorldClock": {
+    "title": "World clock & map",
+    "subtitle": "See the current time across major capitals with an interactive map overlay.",
+    "updatedInRealTime": "Times refresh every second to stay accurate.",
+    "mapCaption": "Hover each pin to see the local time and city name.",
+    "listTitle": "Major capitals",
+    "timezoneLabel": "Timezone"
   }
 }

--- a/src/lang/locale/fr.json
+++ b/src/lang/locale/fr.json
@@ -50,7 +50,8 @@
       "mapsTitle": "Cartes",
       "pleaseSelectLabel": "Vous semblez perdu, veuillez sélectionner un critère ou vous pouvez ",
       "barrelRoll": "faîtes un tonneau"
-    }
+    },
+    "worldClockBtn": "WORLD CLOCK"
   },
   "StreetView": {
     "nearby": {
@@ -218,5 +219,13 @@
   "AlertUpdate": {
     "label": "Une nouvelle version est disponible. Cliquez sur le bouton pour l'obtenir.",
     "btn": "Mettre à jour"
+  },
+  "WorldClock": {
+    "title": "World clock & map",
+    "subtitle": "See the current time across major capitals with an interactive map overlay.",
+    "updatedInRealTime": "Times refresh every second to stay accurate.",
+    "mapCaption": "Hover each pin to see the local time and city name.",
+    "listTitle": "Major capitals",
+    "timezoneLabel": "Timezone"
   }
 }

--- a/src/lang/locale/he.json
+++ b/src/lang/locale/he.json
@@ -50,7 +50,8 @@
       "mapsTitle": "מפות",
       "pleaseSelectLabel": "נדמה שאיבדת את הדרך, אנא בחר סוג או שתוכל ",
       "barrelRoll": "do a barrel roll"
-    }
+    },
+    "worldClockBtn": "WORLD CLOCK"
   },
   "StreetView": {
     "nearby": {
@@ -218,5 +219,13 @@
   "AlertUpdate": {
     "label": "גרסה חדשה מהניילונים זמינה. לחצו כאן כדי לקבל אותה.",
     "btn": "עדכון"
+  },
+  "WorldClock": {
+    "title": "World clock & map",
+    "subtitle": "See the current time across major capitals with an interactive map overlay.",
+    "updatedInRealTime": "Times refresh every second to stay accurate.",
+    "mapCaption": "Hover each pin to see the local time and city name.",
+    "listTitle": "Major capitals",
+    "timezoneLabel": "Timezone"
   }
 }

--- a/src/lang/locale/it.json
+++ b/src/lang/locale/it.json
@@ -50,7 +50,8 @@
       "mapsTitle": "Mappe",
       "pleaseSelectLabel": "Sembri perso, per favore seleziona un tipo oppure ",
       "barrelRoll": "fai una capriola"
-    }
+    },
+    "worldClockBtn": "WORLD CLOCK"
   },
   "StreetView": {
     "nearby": {
@@ -218,5 +219,13 @@
   "AlertUpdate": {
     "label": "È disponibile una nuova versione. Clicca sul pulsante per ottenerla.",
     "btn": "Aggiorna"
+  },
+  "WorldClock": {
+    "title": "World clock & map",
+    "subtitle": "See the current time across major capitals with an interactive map overlay.",
+    "updatedInRealTime": "Times refresh every second to stay accurate.",
+    "mapCaption": "Hover each pin to see the local time and city name.",
+    "listTitle": "Major capitals",
+    "timezoneLabel": "Timezone"
   }
 }

--- a/src/lang/locale/ja.json
+++ b/src/lang/locale/ja.json
@@ -50,7 +50,8 @@
       "mapsTitle": "Maps",
       "pleaseSelectLabel": "失われたようです。タイプを選択するか、可能です。 ",
       "barrelRoll": "バレルロールを使って"
-    }
+    },
+    "worldClockBtn": "WORLD CLOCK"
   },
   "StreetView": {
     "nearby": {
@@ -218,5 +219,13 @@
   "AlertUpdate": {
     "label": "新しいバージョンが利用可能です。ボタンをクリックして入手してください。",
     "btn": "更新"
+  },
+  "WorldClock": {
+    "title": "World clock & map",
+    "subtitle": "See the current time across major capitals with an interactive map overlay.",
+    "updatedInRealTime": "Times refresh every second to stay accurate.",
+    "mapCaption": "Hover each pin to see the local time and city name.",
+    "listTitle": "Major capitals",
+    "timezoneLabel": "Timezone"
   }
 }

--- a/src/lang/locale/kaa.json
+++ b/src/lang/locale/kaa.json
@@ -50,7 +50,8 @@
       "mapsTitle": "Kartalar",
       "pleaseSelectLabel": "Joǵalǵanǵa uqsaysiz, túrin saylań yamasa múmkin ",
       "barrelRoll": "Joqarıǵa"
-    }
+    },
+    "worldClockBtn": "WORLD CLOCK"
   },
   "StreetView": {
     "nearby": {
@@ -218,5 +219,13 @@
   "AlertUpdate": {
     "label": "Jańa versiyası bar. Oǵan iye bolıw ushın túymeni basıń.",
     "btn": "Jańalaw"
+  },
+  "WorldClock": {
+    "title": "World clock & map",
+    "subtitle": "See the current time across major capitals with an interactive map overlay.",
+    "updatedInRealTime": "Times refresh every second to stay accurate.",
+    "mapCaption": "Hover each pin to see the local time and city name.",
+    "listTitle": "Major capitals",
+    "timezoneLabel": "Timezone"
   }
 }

--- a/src/lang/locale/pl.json
+++ b/src/lang/locale/pl.json
@@ -50,7 +50,8 @@
       "mapsTitle": "Mapy",
       "pleaseSelectLabel": "Wygląda na to, że się zgubiłeś, proszę wybierz tryb lub możesz ",
       "barrelRoll": "zrób beczkę"
-    }
+    },
+    "worldClockBtn": "WORLD CLOCK"
   },
   "StreetView": {
     "nearby": {
@@ -218,5 +219,13 @@
   "AlertUpdate": {
     "label": "Nowa wersja jest dostępna. Kliknij na przycisk, aby ją uzyskać.",
     "btn": "Aktualizuj"
+  },
+  "WorldClock": {
+    "title": "World clock & map",
+    "subtitle": "See the current time across major capitals with an interactive map overlay.",
+    "updatedInRealTime": "Times refresh every second to stay accurate.",
+    "mapCaption": "Hover each pin to see the local time and city name.",
+    "listTitle": "Major capitals",
+    "timezoneLabel": "Timezone"
   }
 }

--- a/src/lang/locale/pt.json
+++ b/src/lang/locale/pt.json
@@ -50,7 +50,8 @@
       "mapsTitle": "Maps",
       "pleaseSelectLabel": "You seems lost, please select a type or you can ",
       "barrelRoll": "do a barrel roll"
-    }
+    },
+    "worldClockBtn": "WORLD CLOCK"
   },
   "StreetView": {
     "nearby": {
@@ -218,5 +219,13 @@
   "AlertUpdate": {
     "label": "A new version is available. Click on the button to obtain it.",
     "btn": "Update"
+  },
+  "WorldClock": {
+    "title": "World clock & map",
+    "subtitle": "See the current time across major capitals with an interactive map overlay.",
+    "updatedInRealTime": "Times refresh every second to stay accurate.",
+    "mapCaption": "Hover each pin to see the local time and city name.",
+    "listTitle": "Major capitals",
+    "timezoneLabel": "Timezone"
   }
 }

--- a/src/lang/locale/ru.json
+++ b/src/lang/locale/ru.json
@@ -50,7 +50,8 @@
       "mapsTitle": "Maps",
       "pleaseSelectLabel": "Похоже, вы потерялись, выберите тип или вы можете ",
       "barrelRoll": "Вверх"
-    }
+    },
+    "worldClockBtn": "WORLD CLOCK"
   },
   "StreetView": {
     "nearby": {
@@ -218,5 +219,13 @@
   "AlertUpdate": {
     "label": "Доступна новая версия. Нажмите на кнопку, чтобы получить ее.",
     "btn": "Обновить"
+  },
+  "WorldClock": {
+    "title": "World clock & map",
+    "subtitle": "See the current time across major capitals with an interactive map overlay.",
+    "updatedInRealTime": "Times refresh every second to stay accurate.",
+    "mapCaption": "Hover each pin to see the local time and city name.",
+    "listTitle": "Major capitals",
+    "timezoneLabel": "Timezone"
   }
 }

--- a/src/lang/locale/sv.json
+++ b/src/lang/locale/sv.json
@@ -50,7 +50,8 @@
       "mapsTitle": "Maps",
       "pleaseSelectLabel": "Du verkar vilse, vänligen välj en typ eller så kan du",
       "barrelRoll": "göra en slumpväljning"
-    }
+    },
+    "worldClockBtn": "WORLD CLOCK"
   },
   "StreetView": {
     "nearby": {
@@ -218,5 +219,13 @@
   "AlertUpdate": {
     "label": "En ny version finns tillgänglig. Klicka på knappen för att komma åt den.",
     "btn": "Uppdatera"
+  },
+  "WorldClock": {
+    "title": "World clock & map",
+    "subtitle": "See the current time across major capitals with an interactive map overlay.",
+    "updatedInRealTime": "Times refresh every second to stay accurate.",
+    "mapCaption": "Hover each pin to see the local time and city name.",
+    "listTitle": "Major capitals",
+    "timezoneLabel": "Timezone"
   }
 }

--- a/src/lang/locale/tr.json
+++ b/src/lang/locale/tr.json
@@ -50,7 +50,8 @@
       "mapsTitle": "Maps",
       "pleaseSelectLabel": "You seems lost, please select a type or you can ",
       "barrelRoll": "do a barrel roll"
-    }
+    },
+    "worldClockBtn": "WORLD CLOCK"
   },
   "StreetView": {
     "nearby": {
@@ -218,5 +219,13 @@
   "AlertUpdate": {
     "label": "Yeni bir sürüm mevcut. Güncellemek için butona tıklayın.",
     "btn": "Güncelle"
+  },
+  "WorldClock": {
+    "title": "World clock & map",
+    "subtitle": "See the current time across major capitals with an interactive map overlay.",
+    "updatedInRealTime": "Times refresh every second to stay accurate.",
+    "mapCaption": "Hover each pin to see the local time and city name.",
+    "listTitle": "Major capitals",
+    "timezoneLabel": "Timezone"
   }
 }

--- a/src/lang/locale/zh.json
+++ b/src/lang/locale/zh.json
@@ -50,7 +50,8 @@
       "mapsTitle": "地图",
       "pleaseSelectLabel": "你似乎迷路了，请选择一个类型，或者 ",
       "barrelRoll": "进行翻滚"
-    }
+    },
+    "worldClockBtn": "WORLD CLOCK"
   },
   "StreetView": {
     "nearby": {
@@ -218,5 +219,13 @@
   "AlertUpdate": {
     "label": "新的版本已经推出。点击按钮即可获得。",
     "btn": "更新"
+  },
+  "WorldClock": {
+    "title": "World clock & map",
+    "subtitle": "See the current time across major capitals with an interactive map overlay.",
+    "updatedInRealTime": "Times refresh every second to stay accurate.",
+    "mapCaption": "Hover each pin to see the local time and city name.",
+    "listTitle": "Major capitals",
+    "timezoneLabel": "Timezone"
   }
 }

--- a/src/pages/WorldClockPage.vue
+++ b/src/pages/WorldClockPage.vue
@@ -1,0 +1,271 @@
+<template>
+    <ContentPage class="world-clock-page">
+        <section class="content content--no-background world-clock-page__section">
+            <v-container fluid>
+                <v-row>
+                    <v-col cols="12" md="7">
+                        <h1 class="world-clock-page__title">
+                            {{ $t('WorldClock.title') }}
+                        </h1>
+                        <p class="world-clock-page__subtitle">
+                            {{ $t('WorldClock.subtitle') }}
+                        </p>
+                        <div class="world-clock-page__meta">
+                            <v-icon color="secondary" left>mdi-clock-time-four-outline</v-icon>
+                            <span>{{ $t('WorldClock.updatedInRealTime') }}</span>
+                        </div>
+                    </v-col>
+                </v-row>
+                <v-row class="world-clock-page__content">
+                    <v-col cols="12" md="7">
+                        <div class="world-clock-page__map">
+                            <img :src="mapSrc" alt="World map" />
+                            <v-tooltip
+                                v-for="capital in capitals"
+                                :key="capital.name"
+                                top
+                                open-delay="100"
+                            >
+                                <template v-slot:activator="{ on, attrs }">
+                                    <div
+                                        class="world-clock-page__marker"
+                                        :style="markerStyle(capital)"
+                                        v-bind="attrs"
+                                        v-on="on"
+                                    >
+                                        <span class="world-clock-page__marker__dot"></span>
+                                    </div>
+                                </template>
+                                <div class="world-clock-page__tooltip">
+                                    <div class="world-clock-page__tooltip__city">
+                                        {{ capital.name }}
+                                    </div>
+                                    <div class="world-clock-page__tooltip__time">
+                                        {{ formattedTime(capital) }}
+                                    </div>
+                                </div>
+                            </v-tooltip>
+                        </div>
+                        <p class="world-clock-page__caption">
+                            {{ $t('WorldClock.mapCaption') }}
+                        </p>
+                    </v-col>
+                    <v-col cols="12" md="5">
+                        <v-card elevation="3">
+                            <v-card-title class="world-clock-page__card-title">
+                                {{ $t('WorldClock.listTitle') }}
+                            </v-card-title>
+                            <v-divider></v-divider>
+                            <v-list two-line dense>
+                                <v-list-item v-for="capital in capitals" :key="capital.name">
+                                    <v-list-item-content>
+                                        <v-list-item-title class="world-clock-page__city-name">
+                                            {{ capital.name }}
+                                        </v-list-item-title>
+                                        <v-list-item-subtitle class="world-clock-page__timezone">
+                                            {{ $t('WorldClock.timezoneLabel') }}: {{ capital.timezone }}
+                                        </v-list-item-subtitle>
+                                    </v-list-item-content>
+                                    <v-list-item-action>
+                                        <v-chip color="secondary" dark label>
+                                            {{ formattedTime(capital) }}
+                                        </v-chip>
+                                    </v-list-item-action>
+                                </v-list-item>
+                            </v-list>
+                        </v-card>
+                    </v-col>
+                </v-row>
+            </v-container>
+        </section>
+    </ContentPage>
+</template>
+
+<script>
+import ContentPage from '@/components/page/ContentPage';
+import worldMap from '@/assets/home/world.svg';
+import worldMapDark from '@/assets/home/world-dark.svg';
+
+export default {
+    name: 'WorldClockPage',
+    components: { ContentPage },
+    data() {
+        return {
+            currentTime: new Date(),
+            timerId: null,
+            capitals: [
+                {
+                    name: 'Washington, D.C.',
+                    timezone: 'America/New_York',
+                    position: { top: '43%', left: '25%' },
+                },
+                {
+                    name: 'London',
+                    timezone: 'Europe/London',
+                    position: { top: '33%', left: '48%' },
+                },
+                {
+                    name: 'Paris',
+                    timezone: 'Europe/Paris',
+                    position: { top: '34%', left: '49%' },
+                },
+                {
+                    name: 'Bucharest',
+                    timezone: 'Europe/Bucharest',
+                    position: { top: '38%', left: '54%' },
+                },
+                {
+                    name: 'Cairo',
+                    timezone: 'Africa/Cairo',
+                    position: { top: '42%', left: '53%' },
+                },
+                {
+                    name: 'New Delhi',
+                    timezone: 'Asia/Kolkata',
+                    position: { top: '46%', left: '61%' },
+                },
+                {
+                    name: 'Tokyo',
+                    timezone: 'Asia/Tokyo',
+                    position: { top: '41%', left: '72%' },
+                },
+                {
+                    name: 'Sydney',
+                    timezone: 'Australia/Sydney',
+                    position: { top: '73%', left: '80%' },
+                },
+                {
+                    name: 'Brasília',
+                    timezone: 'America/Sao_Paulo',
+                    position: { top: '63%', left: '34%' },
+                },
+                {
+                    name: 'Johannesburg',
+                    timezone: 'Africa/Johannesburg',
+                    position: { top: '66%', left: '53%' },
+                },
+            ],
+        };
+    },
+    computed: {
+        mapSrc() {
+            return this.$vuetify.theme.dark ? worldMapDark : worldMap;
+        },
+    },
+    mounted() {
+        this.timerId = setInterval(() => {
+            this.currentTime = new Date();
+        }, 1000);
+    },
+    beforeDestroy() {
+        clearInterval(this.timerId);
+    },
+    methods: {
+        formattedTime(capital) {
+            return new Intl.DateTimeFormat(this.$i18n.locale, {
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit',
+                timeZone: capital.timezone,
+            }).format(this.currentTime);
+        },
+        markerStyle(capital) {
+            return {
+                top: capital.position.top,
+                left: capital.position.left,
+            };
+        },
+    },
+};
+</script>
+
+<style scoped lang="scss">
+.world-clock-page {
+    &__section {
+        padding: 2rem 0 3rem 0;
+    }
+    &__title {
+        font-size: 2.25rem;
+        font-weight: 700;
+        margin-bottom: 0.25rem;
+    }
+    &__subtitle {
+        font-size: 1.1rem;
+        margin-bottom: 0.5rem;
+    }
+    &__meta {
+        display: flex;
+        align-items: center;
+        color: var(--v-secondary-base);
+        font-weight: 600;
+        .v-icon {
+            margin-right: 0.35rem;
+        }
+    }
+    &__content {
+        margin-top: 1rem;
+    }
+    &__map {
+        position: relative;
+        border-radius: 12px;
+        overflow: hidden;
+        box-shadow: 0 6px 14px rgba(0, 0, 0, 0.15);
+        background: var(--v-content-base);
+        img {
+            width: 100%;
+            display: block;
+        }
+    }
+    &__marker {
+        position: absolute;
+        transform: translate(-50%, -50%);
+        cursor: pointer;
+        &__dot {
+            width: 14px;
+            height: 14px;
+            border-radius: 50%;
+            background: var(--v-secondary-base);
+            border: 2px solid #fff;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+            display: inline-block;
+        }
+    }
+    &__tooltip {
+        min-width: 140px;
+        &__city {
+            font-weight: 700;
+        }
+        &__time {
+            font-variant-numeric: tabular-nums;
+        }
+    }
+    &__caption {
+        margin-top: 0.5rem;
+        color: var(--v-secondary-base);
+    }
+    &__card-title {
+        font-weight: 700;
+    }
+    &__city-name {
+        font-weight: 700;
+    }
+    &__timezone {
+        font-size: 0.9rem;
+        opacity: 0.8;
+    }
+}
+
+@media (max-width: 960px) {
+    .world-clock-page {
+        &__section {
+            padding-top: 1rem;
+        }
+        &__title {
+            font-size: 2rem;
+        }
+        &__map {
+            margin-bottom: 1rem;
+        }
+    }
+}
+</style>

--- a/src/router.js
+++ b/src/router.js
@@ -1,6 +1,7 @@
 import HistoryPage from '@/pages/HistoryPage';
 import Home from '@/pages/Home';
 import MedalsPage from '@/pages/MedalsPage';
+import WorldClockPage from '@/pages/WorldClockPage';
 import Vue from 'vue';
 import Router from 'vue-router';
 import { GAME_MODE } from './constants';
@@ -54,6 +55,11 @@ export default new Router({
             path: '/medals',
             name: 'Medals',
             component: MedalsPage,
+        },
+        {
+            path: '/world-clock',
+            name: 'WorldClock',
+            component: WorldClockPage,
         },
         {
             path: '/street-view/:modeSelected/:time',


### PR DESCRIPTION
## Summary
- add a world clock page with a live-updating world map and city list for major capitals
- expose the page via a new router entry and header navigation button
- provide translation keys for the new content across locales

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c4db62e68832cbb45c19663169c17)