### PR TITLE
feat(drom): premium institutional product site for DROM aerial system

### DIFF
--- a/.github/workflows/drom.yml
+++ b/.github/workflows/drom.yml
@@ -1,0 +1,44 @@
+name: DROM site
+
+on:
+  pull_request:
+    paths:
+      - 'drom/**'
+      - '.github/workflows/drom.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'drom/**'
+      - '.github/workflows/drom.yml'
+
+jobs:
+  build:
+    name: Build (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20]
+    defaults:
+      run:
+        working-directory: drom
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: drom/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build

--- a/drom/.eslintrc.json
+++ b/drom/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "root": true,
+  "extends": ["next/core-web-vitals"],
+  "rules": {
+    "react/no-unknown-property": "off"
+  }
+}

--- a/drom/.gitignore
+++ b/drom/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+out
+.env*.local
+.DS_Store
+*.tsbuildinfo

--- a/drom/README.md
+++ b/drom/README.md
@@ -1,0 +1,105 @@
+# DROM — Advanced Aerial System
+
+Premium institutional product website for **DROM**, a compact aerial platform for defense and security applications.
+
+Designed for executive briefings, institutional procurement and technical partner evaluation. Built around a real-time WebGL drone inspection sequence that gives the impression of a 10,000-frame cinematic — without loading 10,000 images.
+
+## Stack
+
+- **Next.js 14** (App Router) + **React 18** + **TypeScript**
+- **Tailwind CSS** with custom dark institutional design tokens
+- **Three.js** + **@react-three/fiber** + **@react-three/drei** (procedural drone, no GLB needed)
+- **GSAP** + **ScrollTrigger** (scroll-bound cinematic timeline)
+- **Lenis** (smooth scroll)
+- **Zustand** (minimal scene state)
+
+## Run
+
+```bash
+npm install
+npm run dev      # http://localhost:3000
+npm run build
+npm run start
+```
+
+## Architecture
+
+```
+src/
+├── app/
+│   ├── layout.tsx          # Fonts, metadata, smooth scroll, skip link, noscript
+│   ├── page.tsx            # Composes all sections
+│   ├── globals.css         # Design tokens, panel/HUD utilities
+│   └── icon.svg            # Favicon
+├── components/
+│   ├── layout/             # Header, Footer
+│   ├── system/             # SmoothScroll, NoScriptFallback
+│   ├── ui/                 # Logo, HUDFrame, HUDLine, RadarGraphic, TechnicalCard, Icons, LoadingState
+│   ├── three/
+│   │   ├── DroneModel.tsx        # Procedural tactical drone (primitives only)
+│   │   ├── DroneScene.tsx        # R3F canvas, lighting, scroll-bound choreography
+│   │   ├── CinematicStage.tsx    # 7VH pinned section, ScrollTrigger → scene state
+│   │   ├── StaticDronePoster.tsx # SVG fallback (reduced motion / no WebGL)
+│   │   └── sceneState.ts         # zustand store: progress, phase
+│   ├── cinematic/
+│   │   ├── CinematicHUD.tsx      # Always-on telemetry chrome
+│   │   ├── CinematicOverlay.tsx  # Phase-driven copy crossfade
+│   │   └── phases/               # HeroCopy, InspectionCopy, SpecLock, FeatureCallouts, CommandLayer, LockupCopy
+│   └── sections/                  # PlatformOverview, Specifications, Capabilities,
+│                                  # CommandInterface, EngineeringFocus,
+│                                  # DeploymentContext, TechnicalBriefCTA
+└── lib/                            # cn, useReducedMotion, useDeviceCapability
+```
+
+## Cinematic phases
+
+| # | Range (scroll progress) | Phase           | What happens                                   |
+|---|-------------------------|-----------------|------------------------------------------------|
+| 1 | 0.00 – 0.14             | System wake     | Drone silhouette, key light fades in           |
+| 2 | 0.14 – 0.30             | Hero reveal     | Camera approaches, hero copy + CTAs visible    |
+| 3 | 0.30 – 0.50             | Inspection orbit| Camera orbits 0 → 216° around drone            |
+| 4 | 0.50 – 0.66             | Specification lock | Drone shifts left, spec datasheet on right  |
+| 5 | 0.66 – 0.80             | Feature mapping | Three-quarter pose with four corner callouts   |
+| 6 | 0.80 – 0.92             | Command layer   | Drone scales down, dashboard concept reveals   |
+| 7 | 0.92 – 1.00             | Final lockup    | Centered front-facing pose, mission-ready CTA  |
+
+All camera and drone transforms are **interpolated in real time** with frame-rate-independent damping — no frame sequences are loaded.
+
+## Performance
+
+- Procedural geometry only (no GLB to download)
+- Adaptive DPR + adaptive events
+- Shadows only on `tier === 'high'`
+- Environment maps disabled on `tier === 'low'`
+- ScrollTrigger scrub adapts (0.6 on low-power, 0.8 elsewhere)
+- Static SVG poster swap on `prefers-reduced-motion` or missing WebGL
+- Lenis disabled on `prefers-reduced-motion`
+
+## Content governance
+
+This site uses **only the verified specifications** provided in the brief:
+
+- Dimensions: `395 × 395 × 190 mm`
+- Weight: `1180 g`
+- Application: Defense and security operations
+- System role: Compact tactical aerial platform
+- Operational focus: Mobility, control and rapid integration
+
+It does **not** invent: flight time, range, speed, altitude, payload, communication protocols, encryption, autonomy, AI, sensor specifications, or environmental ratings. The command interface section is explicitly framed as a **conceptual UI**.
+
+## Drone model
+
+A photorealistic GLB was not supplied with the brief. To stay shippable, the drone is built from primitives in `DroneModel.tsx` (frame, arms, motors, three-blade props, top dome antenna, front camera turret, whip antennas, landing skids). When a real GLB becomes available, drop it in `public/models/drom.glb` and replace the procedural geometry with `useGLTF` — the choreography rig will continue to work unchanged.
+
+## Accessibility
+
+- Skip-to-content link
+- Semantic landmarks (`header`, `main`, `section`, `footer`, `nav`, `article`)
+- Visible keyboard focus rings (signal-blue)
+- Decorative motion respects `prefers-reduced-motion`
+- WebGL absence is detected; static schematic shown
+- Color is never the sole signal — labels accompany every status chip
+
+## SEO
+
+`<head>` ships with title template, description, Open Graph, Twitter card, theme color, and color scheme. Add a real OG image at `public/og.png` before launch.

--- a/drom/next-env.d.ts
+++ b/drom/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/drom/next.config.mjs
+++ b/drom/next.config.mjs
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  poweredByHeader: false,
+  images: {
+    formats: ['image/avif', 'image/webp'],
+  },
+  experimental: {
+    optimizePackageImports: ['three', '@react-three/drei', '@react-three/fiber'],
+  },
+};
+
+export default nextConfig;

--- a/drom/package-lock.json
+++ b/drom/package-lock.json
@@ -1,0 +1,7002 @@
+{
+  "name": "drom-website",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "drom-website",
+      "version": "0.1.0",
+      "dependencies": {
+        "@react-three/drei": "^9.114.0",
+        "@react-three/fiber": "^8.17.10",
+        "@studio-freight/lenis": "^1.0.42",
+        "clsx": "^2.1.1",
+        "framer-motion": "^11.11.7",
+        "gsap": "^3.12.5",
+        "next": "14.2.15",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "three": "^0.169.0",
+        "zustand": "^5.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.7.5",
+        "@types/react": "^18.3.11",
+        "@types/react-dom": "^18.3.0",
+        "@types/three": "^0.169.0",
+        "autoprefixer": "^10.4.20",
+        "eslint": "^8.57.1",
+        "eslint-config-next": "14.2.15",
+        "postcss": "^8.4.47",
+        "tailwindcss": "^3.4.13",
+        "typescript": "^5.6.3"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.15.tgz",
+      "integrity": "sha512-S1qaj25Wru2dUpcIZMjxeMVSwkt8BK4dmWHHiBuRstcIyOsMapqT4A4jSB6onvqeygkSSmOkyny9VVx8JIGamQ==",
+      "license": "MIT"
+    },
+    "node_modules/@next/eslint-plugin-next": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.15.tgz",
+      "integrity": "sha512-pKU0iqKRBlFB/ocOI1Ip2CkKePZpYpnw5bEItEkuZ/Nr9FQP1+p7VDWr4VfOdff4i9bFmrOaeaU1bFEyAcxiMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "10.3.10"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.15.tgz",
+      "integrity": "sha512-Rvh7KU9hOUBnZ9TJ28n2Oa7dD9cvDBKua9IKx7cfQQ0GoYUwg9ig31O2oMwH3wm+pE3IkAQ67ZobPfEgurPZIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.15.tgz",
+      "integrity": "sha512-5TGyjFcf8ampZP3e+FyCax5zFVHi+Oe7sZyaKOngsqyaNEpOgkKB3sqmymkZfowy3ufGA/tUgDPPxpQx931lHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.15.tgz",
+      "integrity": "sha512-3Bwv4oc08ONiQ3FiOLKT72Q+ndEMyLNsc/D3qnLMbtUYTQAmkx9E/JRu0DBpHxNddBmNT5hxz1mYBphJ3mfrrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.15.tgz",
+      "integrity": "sha512-k5xf/tg1FBv/M4CMd8S+JL3uV9BnnRmoe7F+GWC3DxkTCD9aewFRH1s5rJ1zkzDa+Do4zyN8qD0N8c84Hu96FQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.15.tgz",
+      "integrity": "sha512-kE6q38hbrRbKEkkVn62reLXhThLRh6/TvgSP56GkFNhU22TbIrQDEMrO7j0IcQHcew2wfykq8lZyHFabz0oBrA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.15.tgz",
+      "integrity": "sha512-PZ5YE9ouy/IdO7QVJeIcyLn/Rc4ml9M2G4y3kCM9MNf1YKvFY4heg3pVa/jQbMro+tP6yc4G2o9LjAz1zxD7tQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.15.tgz",
+      "integrity": "sha512-2raR16703kBvYEQD9HNLyb0/394yfqzmIeyp2nDzcPV4yPjqNUG3ohX6jX00WryXz6s1FXpVhsCo3i+g4RUX+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.15.tgz",
+      "integrity": "sha512-fyTE8cklgkyR1p03kJa5zXEaZ9El+kDNM5A+66+8evQS5e/6v0Gk28LqA0Jet8gKSOyP+OTm/tJHzMlGdQerdQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.15.tgz",
+      "integrity": "sha512-SzqGbsLsP9OwKNUG9nekShTwhj6JSB9ZLMWQ8g1gG6hdE5gQLncbnbymrwy2yVmH9nikSLYRYxYMFu78Ggp7/g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nolyfill/is-core-module": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
+      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@react-spring/animated": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
+      "integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
+      "integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
+      "integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
+      "integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/three": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/three/-/three-9.7.5.tgz",
+      "integrity": "sha512-RxIsCoQfUqOS3POmhVHa1wdWS0wyHAUway73uRLp3GAL5U2iYVNdnzQsep6M2NZ994BlW8TcKuMtQHUqOsy6WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/core": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=6.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "three": ">=0.126"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
+      "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
+      "license": "MIT"
+    },
+    "node_modules/@react-three/drei": {
+      "version": "9.122.0",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.122.0.tgz",
+      "integrity": "sha512-SEO/F/rBCTjlLez7WAlpys+iGe9hty4rNgjZvgkQeXFSiwqD4Hbk/wNHMAbdd8vprO2Aj81mihv4dF5bC7D0CA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@react-spring/three": "~9.7.5",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^2.9.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "react-composer": "^5.0.3",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.7.8",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.0",
+        "tunnel-rat": "^0.1.2",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^8",
+        "react": "^18",
+        "react-dom": "^18",
+        "three": ">=0.137"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
+      "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.26.7",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^1.0.6",
+        "react-reconciler": "^0.27.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.21.0",
+        "suspend-react": "^0.1.3",
+        "zustand": "^3.7.1"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=18 <19",
+        "react-dom": ">=18 <19",
+        "react-native": ">=0.64",
+        "three": ">=0.133"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/zustand": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rushstack/eslint-patch": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
+      "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@studio-freight/lenis": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/@studio-freight/lenis/-/lenis-1.0.42.tgz",
+      "integrity": "sha512-HJAGf2DeM+BTvKzHv752z6Z7zy6bA643nZM7W88Ft9tnw2GsJSp6iJ+3cekjyMIWH+cloL2U9X82dKXgdU8kPg==",
+      "deprecated": "The '@studio-freight/lenis' package has been renamed to 'lenis'. Please update your dependencies: npm install lenis and visit the documentation: https://www.npmjs.com/package/lenis",
+      "license": "MIT"
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
+      "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.26.7.tgz",
+      "integrity": "sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.169.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.169.0.tgz",
+      "integrity": "sha512-oan7qCgJBt03wIaK+4xPWclYRPG9wzcg7Z2f5T8xYTNEF95kh0t0lklxLLYBDo7gQiGLYzE6iF4ta7nXF2bcsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
+      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/type-utils": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
+      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
+      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.2",
+        "@typescript-eslint/types": "^8.59.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
+      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
+      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
+      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
+      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
+      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.2",
+        "@typescript-eslint/tsconfig-utils": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
+      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
+      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
+      "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-2.10.1.tgz",
+      "integrity": "sha512-KnaKdcvkBJ1Irbrzl8XD6WtZltkRjp869Jx8c0ujs9K+9WD+1D7ryBsCiVqJYUqt6i/HR5FxT7RLASieUD+Q5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.126.1"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.353",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
+      "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
+      "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-next": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.15.tgz",
+      "integrity": "sha512-mKg+NC/8a4JKLZRIOBplxXNdStgxy7lzWuedUaCc8tev+Al9mwDUTujQH6W6qXDH9kycWiVo28tADWGvpBsZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/eslint-plugin-next": "14.2.15",
+        "@rushstack/eslint-patch": "^1.3.3",
+        "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-import-resolver-typescript": "^3.5.2",
+        "eslint-plugin-import": "^2.28.1",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
+        "eslint-plugin-react": "^7.33.2",
+        "eslint-plugin-react-hooks": "^4.5.0 || 5.0.0-canary-7118f5dd7-20230705"
+      },
+      "peerDependencies": {
+        "eslint": "^7.23.0 || ^8.0.0",
+        "typescript": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.16.1",
+        "resolve": "^2.0.0-next.6"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
+      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@nolyfill/is-core-module": "1.0.39",
+        "debug": "^4.4.0",
+        "get-tsconfig": "^4.10.0",
+        "is-bun-module": "^2.0.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.13",
+        "unrs-resolver": "^1.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.0.0-canary-7118f5dd7-20230705",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0-canary-7118f5dd7-20230705.tgz",
+      "integrity": "sha512-AZYbMo/NW9chdL7vk6HQzQhT+PvTAEVqWk9ziruUoW2kAOcN5qNyelv70e0F1VNQAbvutOC9oc+xfWycI9FxDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/gsap": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.15.0.tgz",
+      "integrity": "sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
+      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/next": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.15.tgz",
+      "integrity": "sha512-h9ctmOokpoDphRvMGnwOJAedT6zKhwqyZML9mDtspgf4Rh3Pn7UTYKqePNoDvhsWBAO5GoPNYshnAUGIazVGmw==",
+      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.2.15",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.15",
+        "@next/swc-darwin-x64": "14.2.15",
+        "@next/swc-linux-arm64-gnu": "14.2.15",
+        "@next/swc-linux-arm64-musl": "14.2.15",
+        "@next/swc-linux-x64-gnu": "14.2.15",
+        "@next/swc-linux-x64-musl": "14.2.15",
+        "@next/swc-win32-arm64-msvc": "14.2.15",
+        "@next/swc-win32-ia32-msvc": "14.2.15",
+        "@next/swc-win32-x64-msvc": "14.2.15"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-exports-info/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-import/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-composer": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/react-composer/-/react-composer-5.0.3.tgz",
+      "integrity": "sha512-1uWd07EME6XZvMfapwZmc7NgCZqDemcvicRi3wMJzXsQLvZ3L7fTHVyPy1bZdnWXM4iPjYuNE+uJ41MLKeTtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.6.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
+      "integrity": "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "2.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stable-hash": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.169.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.169.0.tgz",
+      "integrity": "sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.7.8.tgz",
+      "integrity": "sha512-BGEZTOIC14U0XIRw3tO4jY7IjP7n7v24nv9JXS1CyeVRWOCkcOMhRnmENUjuV39gktAw4Ofhr0OvIAiTspQrrw==",
+      "deprecated": "Deprecated due to three.js version incompatibility. Please use v0.8.0, instead.",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.151.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/drom/package.json
+++ b/drom/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "drom-website",
+  "version": "0.1.0",
+  "private": true,
+  "description": "DROM — Advanced Aerial System for Defense Applications. Premium institutional product site.",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@react-three/drei": "^9.114.0",
+    "@react-three/fiber": "^8.17.10",
+    "@studio-freight/lenis": "^1.0.42",
+    "clsx": "^2.1.1",
+    "framer-motion": "^11.11.7",
+    "gsap": "^3.12.5",
+    "next": "14.2.15",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "three": "^0.169.0",
+    "zustand": "^5.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.5",
+    "@types/react": "^18.3.11",
+    "@types/react-dom": "^18.3.0",
+    "@types/three": "^0.169.0",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "14.2.15",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.13",
+    "typescript": "^5.6.3"
+  }
+}

--- a/drom/postcss.config.mjs
+++ b/drom/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/drom/src/app/globals.css
+++ b/drom/src/app/globals.css
@@ -1,0 +1,167 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --bg-base: #030508;
+  --bg-secondary: #070b12;
+  --bg-panel: #0b111a;
+  --bg-deep: #101722;
+  --signal-blue: #1d6fff;
+  --signal-cyan: #00aeef;
+  --border-blue: rgba(80, 140, 255, 0.28);
+  --border-blue-soft: rgba(80, 140, 255, 0.14);
+  --text-primary: #f4f7fa;
+  --text-secondary: #9aa4b2;
+  --text-muted: #6f7a89;
+  color-scheme: dark;
+}
+
+html {
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-feature-settings: 'ss01', 'ss02', 'cv11', 'tnum';
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  scroll-behavior: auto; /* Lenis owns scroll */
+}
+
+body {
+  background:
+    radial-gradient(1200px 800px at 80% -10%, rgba(29, 111, 255, 0.06), transparent 60%),
+    radial-gradient(900px 600px at 0% 10%, rgba(0, 174, 239, 0.04), transparent 65%),
+    var(--bg-base);
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+::selection {
+  background: rgba(29, 111, 255, 0.45);
+  color: #fff;
+}
+
+::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+
+/* Lenis */
+html.lenis,
+html.lenis body {
+  height: auto;
+}
+.lenis.lenis-smooth {
+  scroll-behavior: auto !important;
+}
+.lenis.lenis-smooth [data-lenis-prevent] {
+  overscroll-behavior: contain;
+}
+.lenis.lenis-stopped {
+  overflow: hidden;
+}
+
+/* Design utilities */
+@layer components {
+  .shell {
+    @apply mx-auto w-full max-w-shell px-6 md:px-10 lg:px-14;
+  }
+
+  .panel {
+    @apply relative bg-ink-850/60 backdrop-blur-[2px] border border-border-blue/60 rounded-sm;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.03),
+      0 30px 80px -50px rgba(0, 0, 0, 0.85);
+  }
+
+  .panel-deep {
+    @apply relative bg-ink-900/80 border border-border-subtle rounded-sm;
+  }
+
+  .hud-corner::before,
+  .hud-corner::after {
+    content: '';
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    border-color: rgba(80, 140, 255, 0.55);
+    border-style: solid;
+    border-width: 0;
+    pointer-events: none;
+  }
+  .hud-corner::before {
+    top: -1px;
+    left: -1px;
+    border-top-width: 1px;
+    border-left-width: 1px;
+  }
+  .hud-corner::after {
+    bottom: -1px;
+    right: -1px;
+    border-bottom-width: 1px;
+    border-right-width: 1px;
+  }
+
+  .label {
+    @apply font-mono text-label uppercase text-text-muted;
+  }
+  .micro {
+    @apply font-mono text-micro uppercase text-text-muted;
+  }
+  .eyebrow {
+    @apply font-mono text-eyebrow uppercase text-signal-cyan/80;
+  }
+
+  .btn {
+    @apply inline-flex items-center justify-center gap-2 px-5 h-11
+      font-mono text-label uppercase tracking-widest
+      transition-[color,background,border,box-shadow] duration-200 ease-out
+      border rounded-sm focus-visible:outline-none focus-visible:ring-2
+      focus-visible:ring-signal-blue/60;
+  }
+  .btn-primary {
+    @apply btn bg-signal-blue/10 text-text-primary border-signal-blue/60
+      hover:bg-signal-blue/20 hover:border-signal-blue
+      hover:shadow-[0_0_0_1px_rgba(29,111,255,0.45),0_0_30px_-8px_rgba(29,111,255,0.55)];
+  }
+  .btn-ghost {
+    @apply btn bg-transparent text-text-secondary border-border-blue/50
+      hover:text-text-primary hover:border-border-blue;
+  }
+
+  .stat-row {
+    @apply flex items-baseline justify-between gap-6 py-4 border-b border-border-subtle last:border-b-0;
+  }
+
+  .grid-overlay {
+    background-image:
+      linear-gradient(to right, rgba(80, 140, 255, 0.07) 1px, transparent 1px),
+      linear-gradient(to bottom, rgba(80, 140, 255, 0.07) 1px, transparent 1px);
+    background-size: 64px 64px;
+  }
+  .grid-overlay-fine {
+    background-image:
+      linear-gradient(to right, rgba(80, 140, 255, 0.05) 1px, transparent 1px),
+      linear-gradient(to bottom, rgba(80, 140, 255, 0.05) 1px, transparent 1px);
+    background-size: 16px 16px;
+  }
+
+  .vignette::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(ellipse at center, transparent 55%, rgba(0, 0, 0, 0.65) 100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/drom/src/app/icon.svg
+++ b/drom/src/app/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#030508"/>
+  <path d="M4 9 L16 23 L28 9" stroke="#1D6FFF" stroke-width="2.5" fill="none" stroke-linecap="square"/>
+  <path d="M11 9 L16 16 L21 9" stroke="#F4F7FA" stroke-width="1.6" fill="none" stroke-linecap="square"/>
+</svg>

--- a/drom/src/app/layout.tsx
+++ b/drom/src/app/layout.tsx
@@ -1,0 +1,86 @@
+import type { Metadata, Viewport } from 'next';
+import { Sora, Inter, IBM_Plex_Mono } from 'next/font/google';
+import './globals.css';
+import { SmoothScroll } from '@/components/system/SmoothScroll';
+import { NoScriptFallback } from '@/components/system/NoScriptFallback';
+
+const display = Sora({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '600', '700'],
+  variable: '--font-display',
+  display: 'swap',
+});
+
+const sans = Inter({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '600'],
+  variable: '--font-sans',
+  display: 'swap',
+});
+
+const mono = IBM_Plex_Mono({
+  subsets: ['latin'],
+  weight: ['300', '400', '500'],
+  variable: '--font-mono',
+  display: 'swap',
+});
+
+export const metadata: Metadata = {
+  metadataBase: new URL('https://drom.example.com'),
+  title: {
+    default: 'DROM | Advanced Aerial System for Defense Applications',
+    template: '%s | DROM',
+  },
+  description:
+    'DROM is a compact aerial platform engineered for mobility, precision control and rapid tactical integration in demanding operational environments.',
+  applicationName: 'DROM',
+  keywords: [
+    'DROM',
+    'aerial platform',
+    'defense technology',
+    'tactical drone',
+    'compact UAV',
+    'security operations',
+  ],
+  authors: [{ name: 'MDH-X' }],
+  openGraph: {
+    type: 'website',
+    title: 'DROM — Advanced Aerial System for Defense Applications',
+    description:
+      'A compact aerial platform engineered for mobility, precision control and rapid tactical integration.',
+    siteName: 'DROM',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'DROM — Advanced Aerial System for Defense Applications',
+    description:
+      'A compact aerial platform engineered for mobility, precision control and rapid tactical integration.',
+  },
+  robots: { index: true, follow: true },
+};
+
+export const viewport: Viewport = {
+  themeColor: '#030508',
+  colorScheme: 'dark',
+  width: 'device-width',
+  initialScale: 1,
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className={`${display.variable} ${sans.variable} ${mono.variable}`}>
+      <body className="font-sans text-text-primary antialiased">
+        <a
+          href="#overview"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-3 focus:left-3 focus:z-[100]
+            focus:bg-ink-900 focus:border focus:border-signal-blue/60 focus:px-4 focus:py-2
+            focus:text-text-primary focus:font-mono focus:text-label focus:uppercase"
+        >
+          Skip to content
+        </a>
+        <NoScriptFallback />
+        <SmoothScroll>{children}</SmoothScroll>
+      </body>
+    </html>
+  );
+}

--- a/drom/src/app/page.tsx
+++ b/drom/src/app/page.tsx
@@ -1,0 +1,48 @@
+import { Header } from '@/components/layout/Header';
+import { Footer } from '@/components/layout/Footer';
+import { CinematicStage } from '@/components/three/CinematicStage';
+import { PlatformOverview } from '@/components/sections/PlatformOverview';
+import { Specifications } from '@/components/sections/Specifications';
+import { Capabilities } from '@/components/sections/Capabilities';
+import { CommandInterface } from '@/components/sections/CommandInterface';
+import { EngineeringFocus } from '@/components/sections/EngineeringFocus';
+import { DeploymentContext } from '@/components/sections/DeploymentContext';
+import { TechnicalBriefCTA } from '@/components/sections/TechnicalBriefCTA';
+import { InspectionAnchor } from '@/components/sections/InspectionAnchor';
+
+export default function Home() {
+  return (
+    <main id="top">
+      <Header />
+
+      {/* SECTION 1 + 3 — Hero + Cinematic Inspection (one continuous pinned stage) */}
+      <InspectionAnchor>
+        <CinematicStage />
+      </InspectionAnchor>
+
+      {/* SECTION 2 — Platform Overview */}
+      <PlatformOverview />
+
+      {/* SECTION 4 — Key Specifications */}
+      <Specifications />
+
+      {/* SECTION 5 — Operational Capabilities */}
+      <Capabilities />
+
+      {/* SECTION 6 — Interface / Command Layer */}
+      <CommandInterface />
+
+      {/* SECTION 7 — Engineering Focus */}
+      <EngineeringFocus />
+
+      {/* SECTION 8 — Deployment Context */}
+      <DeploymentContext />
+
+      {/* SECTION 9 — Technical Brief CTA */}
+      <TechnicalBriefCTA />
+
+      {/* SECTION 10 — Footer */}
+      <Footer />
+    </main>
+  );
+}

--- a/drom/src/components/cinematic/CinematicHUD.tsx
+++ b/drom/src/components/cinematic/CinematicHUD.tsx
@@ -2,6 +2,10 @@
 
 import { useSceneState, PHASES } from '@/components/three/sceneState';
 
+/**
+ * Bare-bones HUD: a single tiny phase + scrub strip pinned bottom-center.
+ * No crosshair, no telemetry chips, no scanline. Lets the drone breathe.
+ */
 export function CinematicHUD() {
   const progress = useSceneState((s) => s.progress);
   const phase = useSceneState((s) => s.phase);
@@ -10,71 +14,20 @@ export function CinematicHUD() {
 
   return (
     <div className="pointer-events-none absolute inset-0 z-10">
-      {/* Top-left corner chip */}
-      <div className="absolute top-6 left-6 flex items-center gap-3 panel-deep px-3 py-2 hud-corner">
-        <span className="h-1.5 w-1.5 rounded-full bg-signal-cyan animate-pulse-dim" />
-        <span className="micro text-text-secondary">LIVE / SIMULATED PRESENTATION</span>
-      </div>
-
-      {/* Top-right phase indicator */}
-      <div className="absolute top-6 right-6 panel-deep px-3 py-2 hud-corner">
-        <div className="flex items-center gap-3">
-          <span className="micro text-text-muted">PHASE</span>
-          <span className="font-mono text-label uppercase text-text-primary tabular-nums">
-            {String(phase + 1).padStart(2, '0')} / {String(PHASES.length).padStart(2, '0')}
-          </span>
-        </div>
-        <div className="mt-1 micro text-text-secondary">{phaseLabel}</div>
-      </div>
-
-      {/* Bottom-left telemetry stack */}
-      <div className="absolute bottom-6 left-6 panel-deep px-3 py-2 hud-corner">
-        <div className="flex flex-col gap-1">
-          <div className="flex items-center gap-3">
-            <span className="micro text-text-muted">SIGNAL</span>
-            <span className="micro text-text-secondary">LINK CHECK</span>
-          </div>
-          <div className="flex items-center gap-3">
-            <span className="micro text-text-muted">DEVICE</span>
-            <span className="micro text-text-secondary">DROM / 1180g</span>
-          </div>
-        </div>
-      </div>
-
-      {/* Bottom-right scrub bar */}
-      <div className="absolute bottom-6 right-6 w-[260px] max-w-[40vw] panel-deep px-3 py-2 hud-corner">
-        <div className="flex items-center justify-between">
-          <span className="micro text-text-muted">PROFILE SCRUB</span>
-          <span className="font-mono text-micro text-text-secondary tabular-nums">
-            {String(pct).padStart(3, '0')}%
-          </span>
-        </div>
-        <div className="relative mt-2 h-px bg-border-blue/40">
-          <div
+      {/* Phase strip — bottom center, minimal */}
+      <div className="absolute bottom-6 left-1/2 -translate-x-1/2 flex items-center gap-4">
+        <span className="font-mono text-micro uppercase tracking-widest text-text-muted tabular-nums">
+          {String(phase + 1).padStart(2, '0')} / {String(PHASES.length).padStart(2, '0')}
+        </span>
+        <span className="relative h-px w-[180px] bg-border-blue/30">
+          <span
             className="absolute inset-y-0 left-0 bg-signal-cyan"
             style={{ width: `${pct}%` }}
           />
-        </div>
-      </div>
-
-      {/* Subtle scanline */}
-      <div className="absolute inset-0 overflow-hidden">
-        <div
-          aria-hidden
-          className="absolute left-0 right-0 h-px bg-gradient-to-r from-transparent via-signal-blue/40 to-transparent animate-scanline"
-        />
-      </div>
-
-      {/* Crosshair lines */}
-      <div className="absolute inset-0">
-        <div
-          aria-hidden
-          className="absolute top-1/2 left-0 right-0 h-px bg-gradient-to-r from-transparent via-border-blue to-transparent opacity-40"
-        />
-        <div
-          aria-hidden
-          className="absolute left-1/2 top-0 bottom-0 w-px bg-gradient-to-b from-transparent via-border-blue to-transparent opacity-30"
-        />
+        </span>
+        <span className="font-mono text-micro uppercase tracking-widest text-text-secondary">
+          {phaseLabel}
+        </span>
       </div>
     </div>
   );

--- a/drom/src/components/cinematic/CinematicHUD.tsx
+++ b/drom/src/components/cinematic/CinematicHUD.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useSceneState, PHASES } from '@/components/three/sceneState';
+
+export function CinematicHUD() {
+  const progress = useSceneState((s) => s.progress);
+  const phase = useSceneState((s) => s.phase);
+  const phaseLabel = PHASES[phase]?.label ?? '';
+  const pct = Math.round(progress * 100);
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-10">
+      {/* Top-left corner chip */}
+      <div className="absolute top-6 left-6 flex items-center gap-3 panel-deep px-3 py-2 hud-corner">
+        <span className="h-1.5 w-1.5 rounded-full bg-signal-cyan animate-pulse-dim" />
+        <span className="micro text-text-secondary">LIVE / SIMULATED PRESENTATION</span>
+      </div>
+
+      {/* Top-right phase indicator */}
+      <div className="absolute top-6 right-6 panel-deep px-3 py-2 hud-corner">
+        <div className="flex items-center gap-3">
+          <span className="micro text-text-muted">PHASE</span>
+          <span className="font-mono text-label uppercase text-text-primary tabular-nums">
+            {String(phase + 1).padStart(2, '0')} / {String(PHASES.length).padStart(2, '0')}
+          </span>
+        </div>
+        <div className="mt-1 micro text-text-secondary">{phaseLabel}</div>
+      </div>
+
+      {/* Bottom-left telemetry stack */}
+      <div className="absolute bottom-6 left-6 panel-deep px-3 py-2 hud-corner">
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-3">
+            <span className="micro text-text-muted">SIGNAL</span>
+            <span className="micro text-text-secondary">LINK CHECK</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="micro text-text-muted">DEVICE</span>
+            <span className="micro text-text-secondary">DROM / 1180g</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom-right scrub bar */}
+      <div className="absolute bottom-6 right-6 w-[260px] max-w-[40vw] panel-deep px-3 py-2 hud-corner">
+        <div className="flex items-center justify-between">
+          <span className="micro text-text-muted">PROFILE SCRUB</span>
+          <span className="font-mono text-micro text-text-secondary tabular-nums">
+            {String(pct).padStart(3, '0')}%
+          </span>
+        </div>
+        <div className="relative mt-2 h-px bg-border-blue/40">
+          <div
+            className="absolute inset-y-0 left-0 bg-signal-cyan"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Subtle scanline */}
+      <div className="absolute inset-0 overflow-hidden">
+        <div
+          aria-hidden
+          className="absolute left-0 right-0 h-px bg-gradient-to-r from-transparent via-signal-blue/40 to-transparent animate-scanline"
+        />
+      </div>
+
+      {/* Crosshair lines */}
+      <div className="absolute inset-0">
+        <div
+          aria-hidden
+          className="absolute top-1/2 left-0 right-0 h-px bg-gradient-to-r from-transparent via-border-blue to-transparent opacity-40"
+        />
+        <div
+          aria-hidden
+          className="absolute left-1/2 top-0 bottom-0 w-px bg-gradient-to-b from-transparent via-border-blue to-transparent opacity-30"
+        />
+      </div>
+    </div>
+  );
+}

--- a/drom/src/components/cinematic/CinematicOverlay.tsx
+++ b/drom/src/components/cinematic/CinematicOverlay.tsx
@@ -8,7 +8,7 @@ import { FeatureCallouts } from './phases/FeatureCallouts';
 import { CommandLayer } from './phases/CommandLayer';
 import { LockupCopy } from './phases/LockupCopy';
 
-const range = (p: number, a: number, b: number, fadeIn = 0.05, fadeOut = 0.05) => {
+const range = (p: number, a: number, b: number, fadeIn = 0.04, fadeOut = 0.04) => {
   if (p < a - fadeIn) return 0;
   if (p > b + fadeOut) return 0;
   if (p < a) return (p - (a - fadeIn)) / fadeIn;
@@ -16,16 +16,20 @@ const range = (p: number, a: number, b: number, fadeIn = 0.05, fadeOut = 0.05) =
   return 1;
 };
 
+/**
+ * Crossfade overlay synced to the 8-phase scene timeline.
+ * Phase ranges intentionally have small gaps so motion can dominate between text.
+ */
 export function CinematicOverlay() {
   const p = useSceneState((s) => s.progress);
 
   const opacities = {
-    hero: range(p, 0.0, 0.28, 0.0, 0.05),
-    inspection: range(p, 0.30, 0.48, 0.04, 0.05),
-    spec: range(p, 0.50, 0.64, 0.04, 0.05),
-    features: range(p, 0.66, 0.78, 0.04, 0.05),
-    command: range(p, 0.80, 0.90, 0.04, 0.05),
-    lockup: range(p, 0.92, 1.0, 0.04, 0.0),
+    hero: range(p, 0.0, 0.20, 0.0, 0.04),
+    inspection: range(p, 0.26, 0.42, 0.04, 0.04),
+    spec: range(p, 0.55, 0.66, 0.04, 0.04),
+    features: range(p, 0.68, 0.78, 0.04, 0.04),
+    command: range(p, 0.80, 0.90, 0.04, 0.04),
+    lockup: range(p, 0.93, 1.0, 0.04, 0.0),
   };
 
   return (

--- a/drom/src/components/cinematic/CinematicOverlay.tsx
+++ b/drom/src/components/cinematic/CinematicOverlay.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useSceneState } from '@/components/three/sceneState';
+import { HeroCopy } from './phases/HeroCopy';
+import { InspectionCopy } from './phases/InspectionCopy';
+import { SpecLock } from './phases/SpecLock';
+import { FeatureCallouts } from './phases/FeatureCallouts';
+import { CommandLayer } from './phases/CommandLayer';
+import { LockupCopy } from './phases/LockupCopy';
+
+const range = (p: number, a: number, b: number, fadeIn = 0.05, fadeOut = 0.05) => {
+  if (p < a - fadeIn) return 0;
+  if (p > b + fadeOut) return 0;
+  if (p < a) return (p - (a - fadeIn)) / fadeIn;
+  if (p > b) return 1 - (p - b) / fadeOut;
+  return 1;
+};
+
+export function CinematicOverlay() {
+  const p = useSceneState((s) => s.progress);
+
+  const opacities = {
+    hero: range(p, 0.0, 0.28, 0.0, 0.05),
+    inspection: range(p, 0.30, 0.48, 0.04, 0.05),
+    spec: range(p, 0.50, 0.64, 0.04, 0.05),
+    features: range(p, 0.66, 0.78, 0.04, 0.05),
+    command: range(p, 0.80, 0.90, 0.04, 0.05),
+    lockup: range(p, 0.92, 1.0, 0.04, 0.0),
+  };
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-20">
+      <Layer opacity={opacities.hero}>
+        <HeroCopy />
+      </Layer>
+      <Layer opacity={opacities.inspection}>
+        <InspectionCopy />
+      </Layer>
+      <Layer opacity={opacities.spec}>
+        <SpecLock />
+      </Layer>
+      <Layer opacity={opacities.features}>
+        <FeatureCallouts />
+      </Layer>
+      <Layer opacity={opacities.command}>
+        <CommandLayer />
+      </Layer>
+      <Layer opacity={opacities.lockup}>
+        <LockupCopy />
+      </Layer>
+    </div>
+  );
+}
+
+function Layer({ opacity, children }: { opacity: number; children: React.ReactNode }) {
+  return (
+    <div
+      className="absolute inset-0 transition-opacity duration-300"
+      style={{
+        opacity,
+        visibility: opacity < 0.02 ? 'hidden' : 'visible',
+        pointerEvents: opacity > 0.4 ? 'auto' : 'none',
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/drom/src/components/cinematic/phases/CommandLayer.tsx
+++ b/drom/src/components/cinematic/phases/CommandLayer.tsx
@@ -2,79 +2,30 @@
 
 import { RadarGraphic } from '@/components/ui/RadarGraphic';
 
-const STATUS = [
-  { label: 'SYSTEM READINESS', value: 'ONLINE', tone: 'good' as const },
-  { label: 'DEVICE PROFILE', value: 'DROM PLATFORM', tone: 'neutral' as const },
-  { label: 'MISSION STATUS', value: 'STANDBY', tone: 'neutral' as const },
-  { label: 'SIGNAL STATUS', value: 'LINK CHECK', tone: 'attention' as const },
-  { label: 'CONTROL MODE', value: 'OPERATOR REVIEW', tone: 'neutral' as const },
-  { label: 'TELEMETRY', value: 'SIMULATED UI CONCEPT', tone: 'muted' as const },
-];
-
-const TONE: Record<'good' | 'neutral' | 'attention' | 'muted', string> = {
-  good: 'text-signal-cyan',
-  neutral: 'text-text-primary',
-  attention: 'text-signal-amber',
-  muted: 'text-text-muted',
-};
-
+/**
+ * Phase 7 — pulled-back wide. Drone is small and drifts upper-right.
+ * Command interface lives center-left as one tight panel, not a full grid.
+ */
 export function CommandLayer() {
   return (
     <div className="absolute inset-0 flex items-center">
-      <div className="shell w-full grid grid-cols-12 gap-4">
-        {/* Left dashboard column */}
-        <div className="col-span-12 lg:col-span-4 panel hud-corner p-5">
-          <div className="flex items-center justify-between mb-4">
-            <span className="label">DEVICE STATUS</span>
-            <span className="micro text-text-muted">CONCEPT</span>
-          </div>
-          <ul className="divide-y divide-border-subtle">
-            {STATUS.map((s) => (
-              <li key={s.label} className="flex items-center justify-between py-2.5">
-                <span className="micro text-text-muted">{s.label}</span>
-                <span className={`font-mono text-label uppercase ${TONE[s.tone]}`}>{s.value}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-
-        {/* Center radar / map grid */}
-        <div className="hidden lg:flex col-span-4 items-center justify-center">
+      <div className="shell w-full grid grid-cols-12 gap-6">
+        <div className="col-span-12 md:col-span-5 lg:col-span-4">
           <div className="panel hud-corner p-5">
-            <div className="flex items-center justify-between mb-3">
-              <span className="label">MAP GRID</span>
-              <span className="micro text-text-muted">N · 47.06 / E · 21.93</span>
+            <div className="flex items-center justify-between mb-4">
+              <span className="label">COMMAND LAYER</span>
+              <span className="micro text-text-muted">CONCEPT</span>
             </div>
-            <RadarGraphic size={220} />
-            <div className="mt-3 flex items-center justify-between">
-              <span className="micro text-text-muted">RANGE</span>
-              <span className="font-mono text-micro text-text-secondary">CONCEPTUAL</span>
+            <ul className="grid grid-cols-2 gap-x-4 gap-y-2.5">
+              <Row label="STATUS" value="ONLINE" tone="cyan" />
+              <Row label="SIGNAL" value="LINK" />
+              <Row label="MISSION" value="STANDBY" />
+              <Row label="CONTROL" value="REVIEW" />
+            </ul>
+            <div className="mt-4 pt-4 border-t border-border-subtle flex items-center justify-between">
+              <span className="micro text-text-muted">MAP GRID</span>
+              <RadarGraphic size={64} />
             </div>
-          </div>
-        </div>
-
-        {/* Right operator panel */}
-        <div className="col-span-12 lg:col-span-4 panel hud-corner p-5">
-          <div className="flex items-center justify-between mb-4">
-            <span className="label">OPERATOR INTERFACE</span>
-            <span className="micro flex items-center gap-2 text-text-secondary">
-              <span className="h-1.5 w-1.5 rounded-full bg-signal-cyan animate-pulse-dim" />
-              ACTIVE
-            </span>
-          </div>
-
-          <div className="space-y-3">
-            <Row label="ACCESS" value="CONTROLLED" />
-            <Row label="PROFILE" value="OPERATOR REVIEW" />
-            <Row label="WORKFLOW" value="STANDARD" />
-            <Row label="NOTES" value="CLEAR" />
-          </div>
-
-          <div className="mt-5 pt-4 border-t border-border-subtle">
-            <p className="micro text-text-muted">
-              A STRUCTURED COMMAND INTERFACE CONCEPT DESIGNED TO SUPPORT SITUATIONAL AWARENESS,
-              DEVICE MONITORING AND OPERATIONAL CLARITY.
-            </p>
           </div>
         </div>
       </div>
@@ -82,11 +33,17 @@ export function CommandLayer() {
   );
 }
 
-function Row({ label, value }: { label: string; value: string }) {
+function Row({ label, value, tone = 'neutral' }: { label: string; value: string; tone?: 'neutral' | 'cyan' }) {
   return (
-    <div className="flex items-center justify-between gap-4 py-1">
-      <span className="micro text-text-muted">{label}</span>
-      <span className="font-mono text-label text-text-primary">{value}</span>
-    </div>
+    <li>
+      <span className="micro text-text-muted block">{label}</span>
+      <span
+        className={`font-mono text-label uppercase ${
+          tone === 'cyan' ? 'text-signal-cyan' : 'text-text-primary'
+        }`}
+      >
+        {value}
+      </span>
+    </li>
   );
 }

--- a/drom/src/components/cinematic/phases/CommandLayer.tsx
+++ b/drom/src/components/cinematic/phases/CommandLayer.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { RadarGraphic } from '@/components/ui/RadarGraphic';
+
+const STATUS = [
+  { label: 'SYSTEM READINESS', value: 'ONLINE', tone: 'good' as const },
+  { label: 'DEVICE PROFILE', value: 'DROM PLATFORM', tone: 'neutral' as const },
+  { label: 'MISSION STATUS', value: 'STANDBY', tone: 'neutral' as const },
+  { label: 'SIGNAL STATUS', value: 'LINK CHECK', tone: 'attention' as const },
+  { label: 'CONTROL MODE', value: 'OPERATOR REVIEW', tone: 'neutral' as const },
+  { label: 'TELEMETRY', value: 'SIMULATED UI CONCEPT', tone: 'muted' as const },
+];
+
+const TONE: Record<'good' | 'neutral' | 'attention' | 'muted', string> = {
+  good: 'text-signal-cyan',
+  neutral: 'text-text-primary',
+  attention: 'text-signal-amber',
+  muted: 'text-text-muted',
+};
+
+export function CommandLayer() {
+  return (
+    <div className="absolute inset-0 flex items-center">
+      <div className="shell w-full grid grid-cols-12 gap-4">
+        {/* Left dashboard column */}
+        <div className="col-span-12 lg:col-span-4 panel hud-corner p-5">
+          <div className="flex items-center justify-between mb-4">
+            <span className="label">DEVICE STATUS</span>
+            <span className="micro text-text-muted">CONCEPT</span>
+          </div>
+          <ul className="divide-y divide-border-subtle">
+            {STATUS.map((s) => (
+              <li key={s.label} className="flex items-center justify-between py-2.5">
+                <span className="micro text-text-muted">{s.label}</span>
+                <span className={`font-mono text-label uppercase ${TONE[s.tone]}`}>{s.value}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Center radar / map grid */}
+        <div className="hidden lg:flex col-span-4 items-center justify-center">
+          <div className="panel hud-corner p-5">
+            <div className="flex items-center justify-between mb-3">
+              <span className="label">MAP GRID</span>
+              <span className="micro text-text-muted">N · 47.06 / E · 21.93</span>
+            </div>
+            <RadarGraphic size={220} />
+            <div className="mt-3 flex items-center justify-between">
+              <span className="micro text-text-muted">RANGE</span>
+              <span className="font-mono text-micro text-text-secondary">CONCEPTUAL</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Right operator panel */}
+        <div className="col-span-12 lg:col-span-4 panel hud-corner p-5">
+          <div className="flex items-center justify-between mb-4">
+            <span className="label">OPERATOR INTERFACE</span>
+            <span className="micro flex items-center gap-2 text-text-secondary">
+              <span className="h-1.5 w-1.5 rounded-full bg-signal-cyan animate-pulse-dim" />
+              ACTIVE
+            </span>
+          </div>
+
+          <div className="space-y-3">
+            <Row label="ACCESS" value="CONTROLLED" />
+            <Row label="PROFILE" value="OPERATOR REVIEW" />
+            <Row label="WORKFLOW" value="STANDARD" />
+            <Row label="NOTES" value="CLEAR" />
+          </div>
+
+          <div className="mt-5 pt-4 border-t border-border-subtle">
+            <p className="micro text-text-muted">
+              A STRUCTURED COMMAND INTERFACE CONCEPT DESIGNED TO SUPPORT SITUATIONAL AWARENESS,
+              DEVICE MONITORING AND OPERATIONAL CLARITY.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-4 py-1">
+      <span className="micro text-text-muted">{label}</span>
+      <span className="font-mono text-label text-text-primary">{value}</span>
+    </div>
+  );
+}

--- a/drom/src/components/cinematic/phases/FeatureCallouts.tsx
+++ b/drom/src/components/cinematic/phases/FeatureCallouts.tsx
@@ -1,69 +1,37 @@
 'use client';
 
 const FEATURES = [
-  {
-    label: 'COMPACT FRAME',
-    body: 'Optimized physical footprint for agile deployment and transport.',
-    style: 'top-[18%] left-[8%]',
-    line: 'right-0 top-1/2',
-  },
-  {
-    label: 'PRECISION CONTROL',
-    body: 'Interface logic focused on stable handling and responsive operator input.',
-    style: 'top-[18%] right-[8%]',
-    line: 'left-0 top-1/2',
-  },
-  {
-    label: 'RAPID INTEGRATION',
-    body: 'Structured for adoption into operational workflows with minimal visual complexity.',
-    style: 'bottom-[20%] left-[8%]',
-    line: 'right-0 top-1/2',
-  },
-  {
-    label: 'OPERATIONAL MOBILITY',
-    body: 'Compact platform geometry designed around movement, portability and field readiness.',
-    style: 'bottom-[20%] right-[8%]',
-    line: 'left-0 top-1/2',
-  },
+  { label: 'COMPACT FRAME', pos: 'top-[18%] left-[6%]', side: 'right' as const },
+  { label: 'PRECISION CONTROL', pos: 'top-[18%] right-[6%]', side: 'left' as const },
+  { label: 'RAPID INTEGRATION', pos: 'bottom-[20%] left-[6%]', side: 'right' as const },
+  { label: 'OPERATIONAL MOBILITY', pos: 'bottom-[20%] right-[6%]', side: 'left' as const },
 ];
 
 export function FeatureCallouts() {
   return (
     <div className="absolute inset-0 hidden md:block">
       {FEATURES.map((f) => (
-        <div key={f.label} className={`absolute w-[260px] ${f.style}`}>
-          <div className="panel hud-corner p-4">
-            <span className="label text-text-muted">{f.label}</span>
-            <p className="mt-2 text-body text-text-secondary">{f.body}</p>
+        <div key={f.label} className={`absolute ${f.pos}`}>
+          <div className="flex items-center gap-2">
+            {f.side === 'right' && <span className="h-px w-12 bg-signal-blue/60" />}
+            <span className="font-mono text-label uppercase tracking-widest text-text-primary">
+              {f.label}
+            </span>
+            {f.side === 'left' && <span className="h-px w-12 bg-signal-blue/60" />}
           </div>
-          {/* Connector line toward center */}
-          <span
-            aria-hidden
-            className={`absolute h-px w-12 bg-gradient-to-r from-signal-blue/60 to-transparent ${f.line}`}
-          />
+          <div className={`mt-1 ${f.side === 'right' ? '' : 'text-right'}`}>
+            <span className="font-mono text-micro text-text-muted tabular-nums">
+              ◦ ◦ ◦
+            </span>
+          </div>
         </div>
       ))}
 
-      {/* Center anchor pulse */}
+      {/* Tiny center anchor */}
       <span
         aria-hidden
-        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 h-2 w-2 rounded-full bg-signal-cyan/80 shadow-[0_0_24px_rgba(0,174,239,0.65)]"
+        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 h-1.5 w-1.5 rounded-full bg-signal-cyan/90 shadow-[0_0_18px_rgba(0,174,239,0.7)]"
       />
-
-      {/* Mobile fallback */}
-      <div className="md:hidden absolute bottom-8 left-0 right-0 px-6">
-        <div className="panel p-5">
-          <span className="label">FEATURE MAPPING</span>
-          <ul className="mt-3 space-y-3">
-            {FEATURES.map((f) => (
-              <li key={f.label}>
-                <span className="micro text-text-muted block">{f.label}</span>
-                <span className="text-body text-text-secondary">{f.body}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      </div>
     </div>
   );
 }

--- a/drom/src/components/cinematic/phases/FeatureCallouts.tsx
+++ b/drom/src/components/cinematic/phases/FeatureCallouts.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+const FEATURES = [
+  {
+    label: 'COMPACT FRAME',
+    body: 'Optimized physical footprint for agile deployment and transport.',
+    style: 'top-[18%] left-[8%]',
+    line: 'right-0 top-1/2',
+  },
+  {
+    label: 'PRECISION CONTROL',
+    body: 'Interface logic focused on stable handling and responsive operator input.',
+    style: 'top-[18%] right-[8%]',
+    line: 'left-0 top-1/2',
+  },
+  {
+    label: 'RAPID INTEGRATION',
+    body: 'Structured for adoption into operational workflows with minimal visual complexity.',
+    style: 'bottom-[20%] left-[8%]',
+    line: 'right-0 top-1/2',
+  },
+  {
+    label: 'OPERATIONAL MOBILITY',
+    body: 'Compact platform geometry designed around movement, portability and field readiness.',
+    style: 'bottom-[20%] right-[8%]',
+    line: 'left-0 top-1/2',
+  },
+];
+
+export function FeatureCallouts() {
+  return (
+    <div className="absolute inset-0 hidden md:block">
+      {FEATURES.map((f) => (
+        <div key={f.label} className={`absolute w-[260px] ${f.style}`}>
+          <div className="panel hud-corner p-4">
+            <span className="label text-text-muted">{f.label}</span>
+            <p className="mt-2 text-body text-text-secondary">{f.body}</p>
+          </div>
+          {/* Connector line toward center */}
+          <span
+            aria-hidden
+            className={`absolute h-px w-12 bg-gradient-to-r from-signal-blue/60 to-transparent ${f.line}`}
+          />
+        </div>
+      ))}
+
+      {/* Center anchor pulse */}
+      <span
+        aria-hidden
+        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 h-2 w-2 rounded-full bg-signal-cyan/80 shadow-[0_0_24px_rgba(0,174,239,0.65)]"
+      />
+
+      {/* Mobile fallback */}
+      <div className="md:hidden absolute bottom-8 left-0 right-0 px-6">
+        <div className="panel p-5">
+          <span className="label">FEATURE MAPPING</span>
+          <ul className="mt-3 space-y-3">
+            {FEATURES.map((f) => (
+              <li key={f.label}>
+                <span className="micro text-text-muted block">{f.label}</span>
+                <span className="text-body text-text-secondary">{f.body}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/drom/src/components/cinematic/phases/HeroCopy.tsx
+++ b/drom/src/components/cinematic/phases/HeroCopy.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+export function HeroCopy() {
+  return (
+    <div className="absolute inset-0 flex items-center">
+      <div className="shell w-full">
+        <div className="max-w-2xl">
+          <div className="flex items-center gap-3">
+            <span className="h-px w-10 bg-signal-blue/70" />
+            <span className="eyebrow">COMPACT AERIAL PLATFORM / DEFENSE &amp; SECURITY</span>
+          </div>
+          <h1 className="mt-6 font-display text-h1 md:text-display font-semibold leading-[0.96] text-text-primary">
+            DROM
+            <span className="block text-h3 md:text-h2 font-light text-text-secondary mt-3 max-w-[18ch]">
+              Advanced Aerial System for Defense Applications
+            </span>
+          </h1>
+          <p className="mt-7 max-w-prose text-lead text-text-secondary">
+            A compact aerial platform engineered for mobility, precision control and rapid
+            tactical integration in demanding operational environments.
+          </p>
+          <div className="mt-9 flex flex-wrap items-center gap-4 pointer-events-auto">
+            <a href="#inspection" className="btn-primary">
+              Explore Platform
+            </a>
+            <a href="#technical-brief" className="btn-ghost">
+              Request Technical Brief
+            </a>
+          </div>
+
+          <div className="mt-12 grid grid-cols-3 gap-6 max-w-md pointer-events-auto">
+            <Stat label="DIMENSIONS" value="395 × 395 × 190" unit="mm" />
+            <Stat label="WEIGHT" value="1180" unit="g" />
+            <Stat label="ROLE" value="COMPACT" unit="TACTICAL" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value, unit }: { label: string; value: string; unit: string }) {
+  return (
+    <div>
+      <span className="micro text-text-muted block">{label}</span>
+      <span className="mt-1 block font-mono text-label text-text-primary tabular-nums">
+        {value}
+      </span>
+      <span className="micro text-text-muted">{unit}</span>
+    </div>
+  );
+}

--- a/drom/src/components/cinematic/phases/HeroCopy.tsx
+++ b/drom/src/components/cinematic/phases/HeroCopy.tsx
@@ -2,51 +2,32 @@
 
 export function HeroCopy() {
   return (
-    <div className="absolute inset-0 flex items-center">
+    <div className="absolute inset-0 flex items-end pb-20 md:pb-28">
       <div className="shell w-full">
-        <div className="max-w-2xl">
-          <div className="flex items-center gap-3">
-            <span className="h-px w-10 bg-signal-blue/70" />
-            <span className="eyebrow">COMPACT AERIAL PLATFORM / DEFENSE &amp; SECURITY</span>
-          </div>
-          <h1 className="mt-6 font-display text-h1 md:text-display font-semibold leading-[0.96] text-text-primary">
-            DROM
-            <span className="block text-h3 md:text-h2 font-light text-text-secondary mt-3 max-w-[18ch]">
-              Advanced Aerial System for Defense Applications
-            </span>
-          </h1>
-          <p className="mt-7 max-w-prose text-lead text-text-secondary">
-            A compact aerial platform engineered for mobility, precision control and rapid
-            tactical integration in demanding operational environments.
-          </p>
-          <div className="mt-9 flex flex-wrap items-center gap-4 pointer-events-auto">
-            <a href="#inspection" className="btn-primary">
-              Explore Platform
-            </a>
-            <a href="#technical-brief" className="btn-ghost">
-              Request Technical Brief
-            </a>
-          </div>
+        <div className="flex items-center gap-3 mb-4">
+          <span className="h-px w-8 bg-signal-blue/70" />
+          <span className="font-mono text-micro uppercase tracking-widest text-text-muted">
+            COMPACT AERIAL PLATFORM
+          </span>
+        </div>
 
-          <div className="mt-12 grid grid-cols-3 gap-6 max-w-md pointer-events-auto">
-            <Stat label="DIMENSIONS" value="395 × 395 × 190" unit="mm" />
-            <Stat label="WEIGHT" value="1180" unit="g" />
-            <Stat label="ROLE" value="COMPACT" unit="TACTICAL" />
-          </div>
+        <h1 className="font-display font-light text-[12vw] md:text-[7vw] lg:text-[6.5rem] leading-[0.9] text-text-primary tracking-tight">
+          DROM
+        </h1>
+
+        <p className="mt-5 max-w-[28ch] text-lead text-text-secondary">
+          Advanced aerial system for defense applications.
+        </p>
+
+        <div className="mt-8 flex flex-wrap items-center gap-3 pointer-events-auto">
+          <a href="#inspection" className="btn-primary">
+            Explore Platform
+          </a>
+          <a href="#technical-brief" className="btn-ghost">
+            Request Brief
+          </a>
         </div>
       </div>
-    </div>
-  );
-}
-
-function Stat({ label, value, unit }: { label: string; value: string; unit: string }) {
-  return (
-    <div>
-      <span className="micro text-text-muted block">{label}</span>
-      <span className="mt-1 block font-mono text-label text-text-primary tabular-nums">
-        {value}
-      </span>
-      <span className="micro text-text-muted">{unit}</span>
     </div>
   );
 }

--- a/drom/src/components/cinematic/phases/InspectionCopy.tsx
+++ b/drom/src/components/cinematic/phases/InspectionCopy.tsx
@@ -1,54 +1,20 @@
 'use client';
 
+/**
+ * Phase 3 — full orbit. Intentionally wordless: let the drone breathe.
+ * A single corner tag in the bottom-right reinforces context without crowding.
+ */
 export function InspectionCopy() {
   return (
-    <div className="absolute inset-0 flex items-end pb-24 md:items-center md:pb-0">
-      <div className="shell w-full">
-        <div className="flex flex-col gap-3 max-w-md">
-          <span className="eyebrow">PRODUCT INSPECTION</span>
-          <h2 className="font-display text-h3 md:text-h2 font-light text-text-primary leading-tight">
-            Structured rotation.
-            <span className="block text-text-secondary">Mechanical clarity.</span>
-          </h2>
-          <p className="text-body text-text-secondary max-w-prose">
-            DROM is presented through a controlled inspection sequence, designed to reveal
-            structural geometry, material discipline and the deliberate restraint of its
-            tactical form factor.
-          </p>
+    <div className="absolute inset-0 flex items-end justify-end pb-20 pr-8">
+      <div className="text-right">
+        <div className="font-mono text-micro uppercase tracking-widest text-text-muted">
+          FULL ROTATION · 720°
+        </div>
+        <div className="font-mono text-micro uppercase tracking-widest text-signal-cyan/80 mt-1">
+          STRUCTURED INSPECTION
         </div>
       </div>
-
-      {/* Measurement overlays */}
-      <div className="pointer-events-none absolute inset-0">
-        <Measurement label="395 mm" position="top" />
-        <Measurement label="190 mm" position="right" />
-      </div>
-    </div>
-  );
-}
-
-function Measurement({ label, position }: { label: string; position: 'top' | 'right' | 'bottom' | 'left' }) {
-  const styles: Record<string, string> = {
-    top: 'top-[20%] left-1/2 -translate-x-1/2 flex-row',
-    right: 'top-1/2 right-[8%] -translate-y-1/2 flex-col',
-    bottom: 'bottom-[20%] left-1/2 -translate-x-1/2 flex-row',
-    left: 'top-1/2 left-[8%] -translate-y-1/2 flex-col',
-  };
-  return (
-    <div className={`absolute hidden md:flex items-center gap-2 ${styles[position]}`}>
-      {position === 'top' || position === 'bottom' ? (
-        <>
-          <span className="h-px w-16 bg-signal-blue/50" />
-          <span className="font-mono text-micro uppercase text-signal-cyan/80 tracking-widest">{label}</span>
-          <span className="h-px w-16 bg-signal-blue/50" />
-        </>
-      ) : (
-        <>
-          <span className="w-px h-12 bg-signal-blue/50" />
-          <span className="font-mono text-micro uppercase text-signal-cyan/80 tracking-widest">{label}</span>
-          <span className="w-px h-12 bg-signal-blue/50" />
-        </>
-      )}
     </div>
   );
 }

--- a/drom/src/components/cinematic/phases/InspectionCopy.tsx
+++ b/drom/src/components/cinematic/phases/InspectionCopy.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+export function InspectionCopy() {
+  return (
+    <div className="absolute inset-0 flex items-end pb-24 md:items-center md:pb-0">
+      <div className="shell w-full">
+        <div className="flex flex-col gap-3 max-w-md">
+          <span className="eyebrow">PRODUCT INSPECTION</span>
+          <h2 className="font-display text-h3 md:text-h2 font-light text-text-primary leading-tight">
+            Structured rotation.
+            <span className="block text-text-secondary">Mechanical clarity.</span>
+          </h2>
+          <p className="text-body text-text-secondary max-w-prose">
+            DROM is presented through a controlled inspection sequence, designed to reveal
+            structural geometry, material discipline and the deliberate restraint of its
+            tactical form factor.
+          </p>
+        </div>
+      </div>
+
+      {/* Measurement overlays */}
+      <div className="pointer-events-none absolute inset-0">
+        <Measurement label="395 mm" position="top" />
+        <Measurement label="190 mm" position="right" />
+      </div>
+    </div>
+  );
+}
+
+function Measurement({ label, position }: { label: string; position: 'top' | 'right' | 'bottom' | 'left' }) {
+  const styles: Record<string, string> = {
+    top: 'top-[20%] left-1/2 -translate-x-1/2 flex-row',
+    right: 'top-1/2 right-[8%] -translate-y-1/2 flex-col',
+    bottom: 'bottom-[20%] left-1/2 -translate-x-1/2 flex-row',
+    left: 'top-1/2 left-[8%] -translate-y-1/2 flex-col',
+  };
+  return (
+    <div className={`absolute hidden md:flex items-center gap-2 ${styles[position]}`}>
+      {position === 'top' || position === 'bottom' ? (
+        <>
+          <span className="h-px w-16 bg-signal-blue/50" />
+          <span className="font-mono text-micro uppercase text-signal-cyan/80 tracking-widest">{label}</span>
+          <span className="h-px w-16 bg-signal-blue/50" />
+        </>
+      ) : (
+        <>
+          <span className="w-px h-12 bg-signal-blue/50" />
+          <span className="font-mono text-micro uppercase text-signal-cyan/80 tracking-widest">{label}</span>
+          <span className="w-px h-12 bg-signal-blue/50" />
+        </>
+      )}
+    </div>
+  );
+}

--- a/drom/src/components/cinematic/phases/LockupCopy.tsx
+++ b/drom/src/components/cinematic/phases/LockupCopy.tsx
@@ -2,22 +2,15 @@
 
 export function LockupCopy() {
   return (
-    <div className="absolute inset-0 flex items-end pb-20 md:pb-28">
-      <div className="shell w-full">
-        <div className="max-w-3xl mx-auto text-center">
-          <span className="eyebrow">PLATFORM CONCLUSION</span>
-          <h2 className="mt-4 font-display text-h2 md:text-h1 font-light text-text-primary leading-[1.05]">
-            Mission-ready aerial platform
-            <span className="block text-text-secondary">for demanding operational environments.</span>
-          </h2>
-          <div className="mt-8 flex items-center justify-center gap-4 pointer-events-auto">
-            <a href="#technical-brief" className="btn-primary">
-              Request Technical Brief
-            </a>
-            <a href="#technical-brief" className="btn-ghost">
-              Contact Product Team
-            </a>
-          </div>
+    <div className="absolute inset-0 flex items-end pb-20 md:pb-24">
+      <div className="shell w-full text-center">
+        <h2 className="font-display text-h3 md:text-h2 font-light text-text-primary leading-tight max-w-2xl mx-auto">
+          Mission-ready aerial platform.
+        </h2>
+        <div className="mt-6 flex items-center justify-center gap-3 pointer-events-auto">
+          <a href="#technical-brief" className="btn-primary">
+            Request Technical Brief
+          </a>
         </div>
       </div>
     </div>

--- a/drom/src/components/cinematic/phases/LockupCopy.tsx
+++ b/drom/src/components/cinematic/phases/LockupCopy.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+export function LockupCopy() {
+  return (
+    <div className="absolute inset-0 flex items-end pb-20 md:pb-28">
+      <div className="shell w-full">
+        <div className="max-w-3xl mx-auto text-center">
+          <span className="eyebrow">PLATFORM CONCLUSION</span>
+          <h2 className="mt-4 font-display text-h2 md:text-h1 font-light text-text-primary leading-[1.05]">
+            Mission-ready aerial platform
+            <span className="block text-text-secondary">for demanding operational environments.</span>
+          </h2>
+          <div className="mt-8 flex items-center justify-center gap-4 pointer-events-auto">
+            <a href="#technical-brief" className="btn-primary">
+              Request Technical Brief
+            </a>
+            <a href="#technical-brief" className="btn-ghost">
+              Contact Product Team
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/drom/src/components/cinematic/phases/SpecLock.tsx
+++ b/drom/src/components/cinematic/phases/SpecLock.tsx
@@ -1,40 +1,37 @@
 'use client';
 
 const SPECS = [
-  { label: 'DIMENSIONS', value: '395 × 395 × 190 mm' },
-  { label: 'WEIGHT', value: '1180 g' },
-  { label: 'APPLICATION', value: 'Defense and security operations' },
-  { label: 'SYSTEM ROLE', value: 'Compact tactical aerial platform' },
-  { label: 'OPERATIONAL FOCUS', value: 'Mobility, control and rapid integration' },
+  { label: 'DIMENSIONS', value: '395 × 395 × 190', unit: 'mm' },
+  { label: 'WEIGHT', value: '1180', unit: 'g' },
+  { label: 'ROLE', value: 'COMPACT TACTICAL', unit: '' },
 ];
 
 export function SpecLock() {
   return (
     <div className="absolute inset-0 flex items-center">
       <div className="shell w-full grid grid-cols-12 gap-6">
-        {/* Right-aligned spec panel; drone has shifted left in the scene */}
-        <div className="hidden md:block col-span-6" />
-        <aside className="col-span-12 md:col-span-6 panel hud-corner p-6 md:p-7 max-w-[480px] md:ml-auto">
-          <div className="flex items-center justify-between mb-5">
-            <span className="label">KEY SPECIFICATIONS</span>
-            <span className="micro flex items-center gap-2 text-text-secondary">
-              <span className="h-1.5 w-1.5 rounded-full bg-signal-cyan animate-pulse-dim" />
-              VERIFIED
+        <div className="hidden md:block col-span-7" />
+        <aside className="col-span-12 md:col-span-5 max-w-[400px] md:ml-auto">
+          <div className="flex items-center gap-3 mb-6">
+            <span className="h-px w-6 bg-signal-blue/70" />
+            <span className="font-mono text-micro uppercase tracking-widest text-text-muted">
+              VERIFIED SPECIFICATIONS
             </span>
           </div>
 
-          <dl>
+          <dl className="space-y-5">
             {SPECS.map((s) => (
-              <div key={s.label} className="stat-row">
-                <dt className="label text-text-muted shrink-0">{s.label}</dt>
-                <dd className="font-mono text-label text-text-primary text-right">{s.value}</dd>
+              <div key={s.label}>
+                <dt className="font-mono text-micro uppercase tracking-widest text-text-muted">
+                  {s.label}
+                </dt>
+                <dd className="mt-1 font-display text-h4 font-light text-text-primary tabular-nums">
+                  {s.value}{' '}
+                  {s.unit && <span className="text-text-muted text-h6">{s.unit}</span>}
+                </dd>
               </div>
             ))}
           </dl>
-
-          <p className="mt-5 micro text-text-muted">
-            ADDITIONAL VERIFIED SPECIFICATIONS AVAILABLE IN THE TECHNICAL BRIEF.
-          </p>
         </aside>
       </div>
     </div>

--- a/drom/src/components/cinematic/phases/SpecLock.tsx
+++ b/drom/src/components/cinematic/phases/SpecLock.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+const SPECS = [
+  { label: 'DIMENSIONS', value: '395 × 395 × 190 mm' },
+  { label: 'WEIGHT', value: '1180 g' },
+  { label: 'APPLICATION', value: 'Defense and security operations' },
+  { label: 'SYSTEM ROLE', value: 'Compact tactical aerial platform' },
+  { label: 'OPERATIONAL FOCUS', value: 'Mobility, control and rapid integration' },
+];
+
+export function SpecLock() {
+  return (
+    <div className="absolute inset-0 flex items-center">
+      <div className="shell w-full grid grid-cols-12 gap-6">
+        {/* Right-aligned spec panel; drone has shifted left in the scene */}
+        <div className="hidden md:block col-span-6" />
+        <aside className="col-span-12 md:col-span-6 panel hud-corner p-6 md:p-7 max-w-[480px] md:ml-auto">
+          <div className="flex items-center justify-between mb-5">
+            <span className="label">KEY SPECIFICATIONS</span>
+            <span className="micro flex items-center gap-2 text-text-secondary">
+              <span className="h-1.5 w-1.5 rounded-full bg-signal-cyan animate-pulse-dim" />
+              VERIFIED
+            </span>
+          </div>
+
+          <dl>
+            {SPECS.map((s) => (
+              <div key={s.label} className="stat-row">
+                <dt className="label text-text-muted shrink-0">{s.label}</dt>
+                <dd className="font-mono text-label text-text-primary text-right">{s.value}</dd>
+              </div>
+            ))}
+          </dl>
+
+          <p className="mt-5 micro text-text-muted">
+            ADDITIONAL VERIFIED SPECIFICATIONS AVAILABLE IN THE TECHNICAL BRIEF.
+          </p>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/drom/src/components/layout/Footer.tsx
+++ b/drom/src/components/layout/Footer.tsx
@@ -1,0 +1,102 @@
+import { Logo } from '@/components/ui/Logo';
+import { HUDLine } from '@/components/ui/HUDLine';
+
+const COLUMNS: { title: string; items: { label: string; href: string }[] }[] = [
+  {
+    title: 'Platform',
+    items: [
+      { label: 'Overview', href: '#overview' },
+      { label: 'Specifications', href: '#specifications' },
+      { label: 'Capabilities', href: '#capabilities' },
+      { label: 'Engineering', href: '#engineering' },
+    ],
+  },
+  {
+    title: 'Resources',
+    items: [
+      { label: 'Technical Brief', href: '#technical-brief' },
+      { label: 'Deployment Context', href: '#deployment' },
+      { label: 'Interface Concept', href: '#interface' },
+    ],
+  },
+  {
+    title: 'Company',
+    items: [
+      { label: 'MDH-X', href: '#' },
+      { label: 'Press Inquiries', href: '#technical-brief' },
+      { label: 'Contact Product Team', href: '#technical-brief' },
+    ],
+  },
+];
+
+export function Footer() {
+  return (
+    <footer className="relative border-t border-border-blue/25 bg-ink-950">
+      <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-signal-blue/40 to-transparent" />
+      <div className="shell pt-16 pb-10">
+        <div className="grid gap-12 lg:grid-cols-12">
+          <div className="lg:col-span-4">
+            <Logo />
+            <p className="mt-5 max-w-prose text-body text-text-secondary">
+              DROM is a compact aerial platform engineered for mobility, precision control and
+              rapid tactical integration in demanding operational environments.
+            </p>
+            <div className="mt-6 flex items-center gap-4">
+              <span className="micro text-text-muted">SYSTEM STATUS</span>
+              <span className="flex items-center gap-2 font-mono text-micro text-text-secondary">
+                <span className="h-1.5 w-1.5 rounded-full bg-signal-cyan animate-pulse-dim" />
+                ONLINE
+              </span>
+            </div>
+          </div>
+
+          {COLUMNS.map((col) => (
+            <div key={col.title} className="lg:col-span-2">
+              <h4 className="label mb-4">{col.title}</h4>
+              <ul className="space-y-3">
+                {col.items.map((it) => (
+                  <li key={it.label}>
+                    <a
+                      href={it.href}
+                      className="text-body text-text-secondary hover:text-text-primary transition-colors"
+                    >
+                      {it.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+
+          <div className="lg:col-span-2">
+            <h4 className="label mb-4">Contact</h4>
+            <p className="text-body text-text-secondary">
+              For institutional inquiries and procurement, request the technical brief.
+            </p>
+            <a href="#technical-brief" className="mt-4 inline-block btn-ghost">
+              Contact
+            </a>
+          </div>
+        </div>
+
+        <HUDLine className="mt-14" />
+
+        <div className="mt-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-2 micro text-text-muted">
+            <span>DROM / ADVANCED AERIAL SYSTEM</span>
+            <span aria-hidden>·</span>
+            <span>DEFENSE &amp; SECURITY APPLICATIONS</span>
+            <span aria-hidden>·</span>
+            <span>BY MDH-X</span>
+          </div>
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-2 micro text-text-muted">
+            <a href="#" className="hover:text-text-secondary transition-colors">LEGAL</a>
+            <a href="#" className="hover:text-text-secondary transition-colors">PRIVACY</a>
+            <a href="#" className="hover:text-text-secondary transition-colors">TERMS</a>
+            <span>© {new Date().getFullYear()}</span>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/drom/src/components/layout/Header.tsx
+++ b/drom/src/components/layout/Header.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Logo } from '@/components/ui/Logo';
+import { cn } from '@/lib/cn';
+
+const NAV = [
+  { label: 'Overview', href: '#overview' },
+  { label: 'Inspection', href: '#inspection' },
+  { label: 'Specifications', href: '#specifications' },
+  { label: 'Capabilities', href: '#capabilities' },
+  { label: 'Interface', href: '#interface' },
+  { label: 'Engineering', href: '#engineering' },
+];
+
+export function Header() {
+  const [scrolled, setScrolled] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 24);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  return (
+    <header
+      className={cn(
+        'fixed top-0 left-0 right-0 z-50 transition-colors duration-300',
+        scrolled
+          ? 'bg-ink-950/85 backdrop-blur-md border-b border-border-blue/30'
+          : 'bg-transparent border-b border-transparent',
+      )}
+    >
+      <div className="shell flex h-16 items-center justify-between">
+        <a
+          href="#top"
+          className="flex items-center gap-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-signal-blue/60 rounded-sm"
+          aria-label="DROM — Home"
+        >
+          <Logo />
+        </a>
+
+        <nav aria-label="Primary" className="hidden lg:block">
+          <ul className="flex items-center gap-7">
+            {NAV.map((item) => (
+              <li key={item.href}>
+                <a
+                  href={item.href}
+                  className="font-mono text-label uppercase text-text-secondary hover:text-text-primary transition-colors"
+                >
+                  {item.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+
+        <div className="hidden lg:flex items-center gap-3">
+          <span className="micro text-text-muted hidden xl:inline">SECURE PRODUCT BRIEF</span>
+          <a href="#technical-brief" className="btn-primary">
+            Request Brief
+          </a>
+        </div>
+
+        <button
+          className="lg:hidden inline-flex items-center justify-center w-10 h-10 border border-border-blue/40 rounded-sm text-text-secondary"
+          aria-expanded={open}
+          aria-controls="mobile-nav"
+          aria-label="Open navigation"
+          onClick={() => setOpen((v) => !v)}
+        >
+          <span className="sr-only">Menu</span>
+          <span className="relative block w-4 h-2.5">
+            <span className="absolute inset-x-0 top-0 h-px bg-current" />
+            <span className="absolute inset-x-0 bottom-0 h-px bg-current" />
+          </span>
+        </button>
+      </div>
+
+      {open && (
+        <div id="mobile-nav" className="lg:hidden border-t border-border-blue/30 bg-ink-950/95 backdrop-blur">
+          <ul className="shell flex flex-col py-4 gap-1">
+            {NAV.map((item) => (
+              <li key={item.href}>
+                <a
+                  href={item.href}
+                  onClick={() => setOpen(false)}
+                  className="block py-3 font-mono text-label uppercase text-text-secondary hover:text-text-primary"
+                >
+                  {item.label}
+                </a>
+              </li>
+            ))}
+            <li className="pt-4">
+              <a href="#technical-brief" onClick={() => setOpen(false)} className="btn-primary w-full">
+                Request Brief
+              </a>
+            </li>
+          </ul>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/drom/src/components/sections/Capabilities.tsx
+++ b/drom/src/components/sections/Capabilities.tsx
@@ -1,0 +1,70 @@
+import { SectionHeader } from './SectionHeader';
+import { IconMobility, IconPrecision, IconIntegration, IconSecurity } from '@/components/ui/Icons';
+
+const CAPS = [
+  {
+    icon: <IconMobility />,
+    label: 'MOBILITY',
+    title: 'Mobility',
+    body: 'Compact form factor for agile deployment and maneuverability.',
+  },
+  {
+    icon: <IconPrecision />,
+    label: 'PRECISION CONTROL',
+    title: 'Precision Control',
+    body: 'Designed for stable handling and responsive command input.',
+  },
+  {
+    icon: <IconIntegration />,
+    label: 'RAPID INTEGRATION',
+    title: 'Rapid Integration',
+    body: 'Structured for fast adoption into tactical workflows.',
+  },
+  {
+    icon: <IconSecurity />,
+    label: 'ENHANCED SECURITY',
+    title: 'Enhanced Security',
+    body: 'Built around controlled access, operational reliability and secure system logic.',
+  },
+];
+
+export function Capabilities() {
+  return (
+    <section id="capabilities" className="relative py-28 md:py-36">
+      <div className="shell">
+        <SectionHeader
+          index="05 / CAPABILITIES"
+          eyebrow="OPERATIONAL CAPABILITIES"
+          title={
+            <>
+              Four pillars of
+              <span className="block text-text-secondary">tactical readiness.</span>
+            </>
+          }
+        />
+
+        <div className="mt-16 grid gap-px bg-border-subtle md:grid-cols-2 lg:grid-cols-4 border border-border-blue/30 rounded-sm overflow-hidden">
+          {CAPS.map((c, i) => (
+            <article
+              key={c.title}
+              className="group relative bg-ink-900/80 p-7 transition-colors hover:bg-ink-850"
+            >
+              <div className="flex items-center justify-between mb-8">
+                <span className="micro text-text-muted">/ {String(i + 1).padStart(2, '0')}</span>
+                <span className="text-signal-blue/90">{c.icon}</span>
+              </div>
+              <h3 className="font-display text-h5 text-text-primary leading-tight">{c.title}</h3>
+              <p className="mt-3 text-body text-text-secondary">{c.body}</p>
+
+              <span
+                aria-hidden
+                className="absolute left-7 right-7 bottom-7 h-px bg-gradient-to-r from-signal-blue/40 to-transparent
+                  scale-x-0 group-hover:scale-x-100 origin-left transition-transform"
+              />
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/drom/src/components/sections/CommandInterface.tsx
+++ b/drom/src/components/sections/CommandInterface.tsx
@@ -1,0 +1,133 @@
+import { SectionHeader } from './SectionHeader';
+import { RadarGraphic } from '@/components/ui/RadarGraphic';
+import { HUDLine } from '@/components/ui/HUDLine';
+
+const MODULES = [
+  'SYSTEM READINESS',
+  'DEVICE PROFILE',
+  'MISSION STATUS',
+  'SIGNAL STATUS',
+  'TELEMETRY',
+  'MAP GRID',
+  'OPERATIONAL NOTES',
+  'ACCESS STATUS',
+];
+
+export function CommandInterface() {
+  return (
+    <section id="interface" className="relative py-28 md:py-36 bg-ink-900/60">
+      <div className="absolute inset-0 grid-overlay opacity-[0.10] pointer-events-none" aria-hidden />
+      <div className="shell">
+        <div className="grid gap-12 lg:grid-cols-12 items-center">
+          {/* Copy */}
+          <div className="lg:col-span-5">
+            <SectionHeader
+              index="06 / INTERFACE"
+              eyebrow="COMMAND INTERFACE LAYER"
+              title={
+                <>
+                  Structured for
+                  <span className="block text-text-secondary">situational clarity.</span>
+                </>
+              }
+              intro={
+                <>
+                  A structured command interface concept designed to support situational
+                  awareness, device monitoring and operational clarity. This section presents
+                  the interface as a conceptual layer; specific software functionality is
+                  validated under the technical brief.
+                </>
+              }
+            />
+
+            <ul className="mt-10 grid grid-cols-2 gap-px bg-border-subtle border border-border-blue/30 rounded-sm overflow-hidden">
+              {MODULES.map((m) => (
+                <li key={m} className="bg-ink-900/80 px-4 py-3 micro text-text-secondary">
+                  {m}
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Dashboard visual */}
+          <div className="lg:col-span-7">
+            <div className="panel hud-corner relative p-5 md:p-6 overflow-hidden">
+              <div className="absolute inset-0 grid-overlay-fine opacity-[0.10] pointer-events-none" aria-hidden />
+
+              <div className="relative grid gap-4 md:grid-cols-3">
+                {/* Status block */}
+                <div className="md:col-span-1 space-y-3">
+                  <Block label="DEVICE PROFILE" value="DROM PLATFORM" />
+                  <Block label="SYSTEM READINESS" value="ONLINE" tone="cyan" />
+                  <Block label="MISSION STATUS" value="STANDBY" />
+                  <Block label="SIGNAL STATUS" value="LINK CHECK" tone="amber" />
+                </div>
+
+                {/* Radar / map */}
+                <div className="md:col-span-1 panel-deep p-4 flex flex-col items-center">
+                  <div className="flex w-full items-center justify-between">
+                    <span className="micro text-text-muted">MAP GRID</span>
+                    <span className="micro text-text-secondary">CONCEPT</span>
+                  </div>
+                  <RadarGraphic className="my-3" size={180} />
+                  <div className="w-full mt-2 flex items-center justify-between">
+                    <span className="micro text-text-muted">SECTOR</span>
+                    <span className="font-mono text-micro text-text-secondary">A · 04</span>
+                  </div>
+                </div>
+
+                {/* Telemetry */}
+                <div className="md:col-span-1 panel-deep p-4">
+                  <span className="micro text-text-muted">TELEMETRY · SIMULATED UI</span>
+                  <div className="mt-3 space-y-2">
+                    {['ATTITUDE', 'VECTOR', 'BUS', 'I/O'].map((row) => (
+                      <div key={row}>
+                        <div className="flex items-center justify-between">
+                          <span className="micro text-text-muted">{row}</span>
+                          <span className="font-mono text-micro text-text-secondary">—</span>
+                        </div>
+                        <div className="mt-1 h-px bg-border-blue/40" />
+                      </div>
+                    ))}
+                  </div>
+                  <HUDLine className="my-4" />
+                  <div className="flex items-center justify-between">
+                    <span className="micro text-text-muted">CONTROL MODE</span>
+                    <span className="font-mono text-label text-text-primary">OPERATOR REVIEW</span>
+                  </div>
+                </div>
+              </div>
+
+              <div className="relative mt-5 flex items-center justify-between">
+                <span className="micro text-text-muted">SECURE ACCESS LABEL · CONCEPTUAL UI</span>
+                <span className="micro text-text-muted">DROM / INTERFACE PREVIEW</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Block({
+  label,
+  value,
+  tone = 'neutral',
+}: {
+  label: string;
+  value: string;
+  tone?: 'neutral' | 'cyan' | 'amber';
+}) {
+  const tones: Record<string, string> = {
+    neutral: 'text-text-primary',
+    cyan: 'text-signal-cyan',
+    amber: 'text-signal-amber',
+  };
+  return (
+    <div className="panel-deep p-4">
+      <span className="micro text-text-muted">{label}</span>
+      <div className={`mt-2 font-mono text-label uppercase ${tones[tone]}`}>{value}</div>
+    </div>
+  );
+}

--- a/drom/src/components/sections/DeploymentContext.tsx
+++ b/drom/src/components/sections/DeploymentContext.tsx
@@ -1,0 +1,62 @@
+import { SectionHeader } from './SectionHeader';
+
+const CONTEXTS = [
+  'Security Operations',
+  'Infrastructure Monitoring',
+  'Field Evaluation',
+  'Tactical Workflow Integration',
+  'Technical Demonstration',
+  'Institutional Procurement Review',
+];
+
+export function DeploymentContext() {
+  return (
+    <section id="deployment" className="relative py-28 md:py-36 bg-ink-900/60">
+      <div className="shell grid gap-12 lg:grid-cols-12">
+        <div className="lg:col-span-5">
+          <SectionHeader
+            index="08 / DEPLOYMENT"
+            eyebrow="DEPLOYMENT CONTEXT"
+            title={
+              <>
+                Built for evaluation by
+                <span className="block text-text-secondary">institutional stakeholders.</span>
+              </>
+            }
+            intro={
+              <>
+                DROM is positioned for professional environments where compact aerial mobility,
+                structured control and rapid integration are important evaluation criteria. The
+                platform presentation is designed for stakeholders assessing portability,
+                operational workflow fit and technical integration requirements.
+              </>
+            }
+          />
+        </div>
+
+        <div className="lg:col-span-7">
+          <div className="panel hud-corner p-6 md:p-8">
+            <div className="flex items-center justify-between mb-6">
+              <span className="label">CONTEXT MATRIX</span>
+              <span className="micro text-text-muted">EVALUATION SCOPE</span>
+            </div>
+            <ul className="grid grid-cols-1 sm:grid-cols-2 gap-px bg-border-subtle border border-border-blue/30 rounded-sm overflow-hidden">
+              {CONTEXTS.map((ctx, i) => (
+                <li key={ctx} className="bg-ink-900/80 p-5">
+                  <div className="flex items-center justify-between">
+                    <span className="micro text-text-muted">CTX-{String(i + 1).padStart(2, '0')}</span>
+                    <span className="h-1.5 w-1.5 rounded-full bg-signal-cyan/80" />
+                  </div>
+                  <div className="mt-3 font-display text-h6 text-text-primary">{ctx}</div>
+                </li>
+              ))}
+            </ul>
+            <p className="mt-6 micro text-text-muted">
+              CONTEXT LABELS DESCRIBE EVALUATION DOMAINS. THEY DO NOT CONSTITUTE OPERATIONAL CLAIMS.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/drom/src/components/sections/EngineeringFocus.tsx
+++ b/drom/src/components/sections/EngineeringFocus.tsx
@@ -1,0 +1,100 @@
+import { SectionHeader } from './SectionHeader';
+
+const BLOCKS = [
+  {
+    code: 'EF-01',
+    title: 'Mechanical Design',
+    body: 'Compact geometry, rigid structure and modular component layout.',
+    diagram: (
+      <svg viewBox="0 0 200 120" className="h-full w-full text-signal-blue/60" aria-hidden>
+        <rect x="20" y="40" width="160" height="40" fill="none" stroke="currentColor" />
+        <rect x="40" y="50" width="120" height="20" fill="none" stroke="currentColor" opacity="0.5" />
+        <line x1="20" y1="20" x2="180" y2="20" stroke="currentColor" opacity="0.4" />
+        <line x1="20" y1="100" x2="180" y2="100" stroke="currentColor" opacity="0.4" />
+        <line x1="20" y1="20" x2="20" y2="100" stroke="currentColor" opacity="0.4" />
+        <line x1="180" y1="20" x2="180" y2="100" stroke="currentColor" opacity="0.4" />
+        <text x="20" y="14" fontFamily="ui-monospace" fontSize="6" fill="currentColor" letterSpacing="1">395 mm</text>
+        <text x="186" y="64" fontFamily="ui-monospace" fontSize="6" fill="currentColor" letterSpacing="1" transform="rotate(90 186 64)">190 mm</text>
+      </svg>
+    ),
+  },
+  {
+    code: 'EF-02',
+    title: 'Control Architecture',
+    body: 'Interface logic focused on responsiveness, operator clarity and consistent handling.',
+    diagram: (
+      <svg viewBox="0 0 200 120" className="h-full w-full text-signal-blue/60" aria-hidden>
+        <circle cx="100" cy="60" r="36" fill="none" stroke="currentColor" />
+        <circle cx="100" cy="60" r="20" fill="none" stroke="currentColor" opacity="0.5" />
+        <line x1="100" y1="10" x2="100" y2="40" stroke="currentColor" />
+        <line x1="100" y1="80" x2="100" y2="110" stroke="currentColor" />
+        <line x1="20" y1="60" x2="64" y2="60" stroke="currentColor" />
+        <line x1="136" y1="60" x2="180" y2="60" stroke="currentColor" />
+        <circle cx="100" cy="60" r="3" fill="currentColor" />
+      </svg>
+    ),
+  },
+  {
+    code: 'EF-03',
+    title: 'Deployment Readiness',
+    body: 'Product structure designed for fast transport, setup and field-level integration.',
+    diagram: (
+      <svg viewBox="0 0 200 120" className="h-full w-full text-signal-blue/60" aria-hidden>
+        <path d="M20 100 L100 30 L180 100 Z" fill="none" stroke="currentColor" />
+        <line x1="40" y1="100" x2="160" y2="100" stroke="currentColor" opacity="0.5" />
+        <line x1="100" y1="30" x2="100" y2="100" stroke="currentColor" opacity="0.4" />
+        <circle cx="100" cy="30" r="3" fill="currentColor" />
+      </svg>
+    ),
+  },
+  {
+    code: 'EF-04',
+    title: 'System Security',
+    body: 'Access-controlled operational logic and secure workflow-oriented design.',
+    diagram: (
+      <svg viewBox="0 0 200 120" className="h-full w-full text-signal-blue/60" aria-hidden>
+        <path d="M100 20 L160 40 V70 C160 90 130 105 100 110 C70 105 40 90 40 70 V40 Z" fill="none" stroke="currentColor" />
+        <path d="M82 65 L96 78 L120 54" fill="none" stroke="currentColor" />
+      </svg>
+    ),
+  },
+];
+
+export function EngineeringFocus() {
+  return (
+    <section id="engineering" className="relative py-28 md:py-36">
+      <div className="absolute inset-0 grid-overlay-fine opacity-[0.10] pointer-events-none" aria-hidden />
+      <div className="shell">
+        <SectionHeader
+          index="07 / ENGINEERING"
+          eyebrow="ENGINEERING FOCUS"
+          title={
+            <>
+              Discipline at the level
+              <span className="block text-text-secondary">of every subsystem.</span>
+            </>
+          }
+        />
+
+        <div className="mt-16 grid gap-5 md:grid-cols-2">
+          {BLOCKS.map((b) => (
+            <article key={b.code} className="panel hud-corner p-7 grid grid-cols-12 gap-5">
+              <div className="col-span-12 lg:col-span-7">
+                <div className="flex items-center gap-3">
+                  <span className="micro text-text-muted">{b.code}</span>
+                  <span className="h-px w-6 bg-signal-blue/60" />
+                  <span className="micro text-signal-cyan/80">SUBSYSTEM</span>
+                </div>
+                <h3 className="mt-4 font-display text-h4 text-text-primary leading-tight">{b.title}</h3>
+                <p className="mt-3 text-body text-text-secondary max-w-prose">{b.body}</p>
+              </div>
+              <div className="col-span-12 lg:col-span-5">
+                <div className="panel-deep p-3 h-32">{b.diagram}</div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/drom/src/components/sections/InspectionAnchor.tsx
+++ b/drom/src/components/sections/InspectionAnchor.tsx
@@ -1,0 +1,12 @@
+/**
+ * Anchor wrapper that exposes both #inspection (mid-cinematic) and contains the
+ * pinned cinematic stage. Splits the main hero/cinematic into a single tall section
+ * so scrolljacking is contained and predictable.
+ */
+export function InspectionAnchor({ children }: { children: React.ReactNode }) {
+  return (
+    <div id="inspection" className="relative">
+      {children}
+    </div>
+  );
+}

--- a/drom/src/components/sections/PlatformOverview.tsx
+++ b/drom/src/components/sections/PlatformOverview.tsx
@@ -1,0 +1,69 @@
+import { SectionHeader } from './SectionHeader';
+import { TechnicalCard } from '@/components/ui/TechnicalCard';
+import { IconStructure, IconControl, IconIntegration } from '@/components/ui/Icons';
+
+const CARDS = [
+  {
+    icon: <IconStructure />,
+    label: 'COMPACT ARCHITECTURE',
+    title: 'Compact Architecture',
+    body:
+      'A disciplined form factor designed for portability, structural clarity and efficient handling.',
+  },
+  {
+    icon: <IconControl />,
+    label: 'PRECISION-ORIENTED CONTROL',
+    title: 'Precision-Oriented Control',
+    body:
+      'A control-focused platform concept built around operator clarity and responsive system behavior.',
+  },
+  {
+    icon: <IconIntegration />,
+    label: 'RAPID OPERATIONAL INTEGRATION',
+    title: 'Rapid Operational Integration',
+    body:
+      'A product structure intended to support faster evaluation, deployment planning and workflow integration.',
+  },
+];
+
+export function PlatformOverview() {
+  return (
+    <section id="overview" className="relative py-28 md:py-36">
+      <div className="absolute inset-0 grid-overlay opacity-[0.10] pointer-events-none" aria-hidden />
+      <div className="shell">
+        <SectionHeader
+          index="02 / OVERVIEW"
+          eyebrow="PLATFORM OVERVIEW"
+          title={
+            <>
+              Engineered for controlled mobility
+              <span className="block text-text-secondary">
+                and rapid operational integration.
+              </span>
+            </>
+          }
+          intro={
+            <>
+              DROM is a compact aerial platform designed for controlled mobility, precise handling
+              and rapid operational integration. Its architecture supports deployment in scenarios
+              where size, responsiveness and secure control are critical.
+            </>
+          }
+        />
+
+        <div className="mt-16 grid gap-5 md:grid-cols-3">
+          {CARDS.map((c, i) => (
+            <TechnicalCard
+              key={c.title}
+              index={`/ ${String(i + 1).padStart(2, '0')}`}
+              label={c.label}
+              title={c.title}
+              body={c.body}
+              icon={c.icon}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/drom/src/components/sections/SectionHeader.tsx
+++ b/drom/src/components/sections/SectionHeader.tsx
@@ -1,0 +1,23 @@
+interface SectionHeaderProps {
+  index: string;
+  eyebrow: string;
+  title: React.ReactNode;
+  intro?: React.ReactNode;
+  align?: 'left' | 'center';
+}
+
+export function SectionHeader({ index, eyebrow, title, intro, align = 'left' }: SectionHeaderProps) {
+  return (
+    <header className={align === 'center' ? 'text-center mx-auto max-w-3xl' : 'max-w-3xl'}>
+      <div className={`flex items-center gap-4 ${align === 'center' ? 'justify-center' : ''}`}>
+        <span className="micro text-text-muted">{index}</span>
+        <span className="h-px w-10 bg-signal-blue/60" />
+        <span className="eyebrow">{eyebrow}</span>
+      </div>
+      <h2 className="mt-5 font-display text-h3 md:text-h2 font-light leading-[1.05] text-text-primary">
+        {title}
+      </h2>
+      {intro && <p className="mt-5 text-lead text-text-secondary max-w-prose">{intro}</p>}
+    </header>
+  );
+}

--- a/drom/src/components/sections/Specifications.tsx
+++ b/drom/src/components/sections/Specifications.tsx
@@ -1,0 +1,104 @@
+import { SectionHeader } from './SectionHeader';
+
+const SPECS = [
+  { label: 'DIMENSIONS', value: '395 × 395 × 190 mm', note: 'Drone body envelope' },
+  { label: 'WEIGHT', value: '1180 g', note: 'Platform mass' },
+  { label: 'APPLICATION', value: 'Defense and security operations', note: 'Intended use context' },
+  { label: 'SYSTEM ROLE', value: 'Compact tactical aerial platform', note: 'Primary product role' },
+  { label: 'OPERATIONAL FOCUS', value: 'Mobility, control and rapid integration', note: 'Design priorities' },
+];
+
+const SUBSYSTEMS = [
+  { label: 'PLATFORM', value: 'Drone unit' },
+  { label: 'OPERATOR INPUT', value: 'Handheld controller' },
+  { label: 'VISUAL FEEDBACK', value: 'FPV goggles' },
+];
+
+const COMPONENT_DIMS = [
+  { label: 'CONTROLLER', value: '160 × 195 × 75 mm' },
+  { label: 'FPV GOGGLES', value: '195 × 150 × 95 mm' },
+];
+
+export function Specifications() {
+  return (
+    <section id="specifications" className="relative py-28 md:py-36 bg-ink-900/60">
+      <div className="absolute inset-0 grid-overlay-fine opacity-[0.10] pointer-events-none" aria-hidden />
+      <div className="shell">
+        <SectionHeader
+          index="04 / SPECIFICATIONS"
+          eyebrow="DIMENSIONAL DATA"
+          title={
+            <>
+              Verified technical
+              <span className="block text-text-secondary">specifications.</span>
+            </>
+          }
+          intro={
+            <>
+              Only validated values are listed. Performance data, communications behavior,
+              autonomy and environmental ratings are intentionally omitted and may be shared
+              under the technical brief.
+            </>
+          }
+        />
+
+        <div className="mt-16 grid gap-6 lg:grid-cols-12">
+          {/* Primary spec sheet */}
+          <div className="lg:col-span-7 panel hud-corner p-6 md:p-8">
+            <div className="flex items-center justify-between mb-6">
+              <span className="label">KEY SPECIFICATIONS · PLATFORM</span>
+              <span className="micro flex items-center gap-2 text-text-secondary">
+                <span className="h-1.5 w-1.5 rounded-full bg-signal-cyan animate-pulse-dim" />
+                VERIFIED
+              </span>
+            </div>
+            <dl className="divide-y divide-border-subtle">
+              {SPECS.map((s) => (
+                <div key={s.label} className="grid grid-cols-12 items-baseline gap-4 py-4">
+                  <dt className="col-span-4 label text-text-muted">{s.label}</dt>
+                  <dd className="col-span-5 font-mono text-label text-text-primary">{s.value}</dd>
+                  <dd className="col-span-3 micro text-text-muted text-right hidden md:block">
+                    {s.note}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+            <p className="mt-6 micro text-text-muted">
+              ADDITIONAL VERIFIED TECHNICAL SPECIFICATIONS MAY BE PROVIDED IN THE TECHNICAL BRIEF.
+            </p>
+          </div>
+
+          {/* Side: subsystems + component dims */}
+          <div className="lg:col-span-5 grid gap-6">
+            <div className="panel hud-corner p-6">
+              <span className="label">SYSTEM COMPOSITION</span>
+              <ul className="mt-4 divide-y divide-border-subtle">
+                {SUBSYSTEMS.map((s) => (
+                  <li key={s.label} className="stat-row">
+                    <span className="micro text-text-muted">{s.label}</span>
+                    <span className="font-mono text-label text-text-primary">{s.value}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="panel hud-corner p-6">
+              <span className="label">COMPONENT DIMENSIONS</span>
+              <ul className="mt-4 divide-y divide-border-subtle">
+                {COMPONENT_DIMS.map((s) => (
+                  <li key={s.label} className="stat-row">
+                    <span className="micro text-text-muted">{s.label}</span>
+                    <span className="font-mono text-label text-text-primary">{s.value}</span>
+                  </li>
+                ))}
+              </ul>
+              <p className="mt-4 micro text-text-muted">
+                APPROXIMATE COMPONENT FOOTPRINTS, FROM PRODUCT REFERENCE DOCUMENTATION.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/drom/src/components/sections/TechnicalBriefCTA.tsx
+++ b/drom/src/components/sections/TechnicalBriefCTA.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useState } from 'react';
+import { SectionHeader } from './SectionHeader';
+
+const AREAS = [
+  'Procurement evaluation',
+  'Technical integration',
+  'Investor briefing',
+  'Press / institutional inquiry',
+  'Other',
+];
+
+export function TechnicalBriefCTA() {
+  const [submitted, setSubmitted] = useState(false);
+
+  return (
+    <section id="technical-brief" className="relative py-28 md:py-36">
+      <div className="absolute inset-0 grid-overlay opacity-[0.10] pointer-events-none" aria-hidden />
+      <div className="shell grid gap-12 lg:grid-cols-12">
+        <div className="lg:col-span-5">
+          <SectionHeader
+            index="09 / BRIEF"
+            eyebrow="REQUEST THE TECHNICAL BRIEF"
+            title={
+              <>
+                Request the DROM
+                <span className="block text-text-secondary">Technical Brief.</span>
+              </>
+            }
+            intro={
+              <>
+                For detailed specifications, integration requirements and deployment context,
+                request the technical brief. Distribution is reviewed on a per-request basis.
+              </>
+            }
+          />
+
+          <div className="mt-10 space-y-4">
+            <Row label="DELIVERY" value="DIGITAL · ON REVIEW" />
+            <Row label="LANGUAGE" value="EN / RO" />
+            <Row label="RESPONSE TARGET" value="2–5 BUSINESS DAYS" />
+            <Row label="CONFIDENTIALITY" value="HANDLED ON REQUEST" />
+          </div>
+        </div>
+
+        <div className="lg:col-span-7">
+          <form
+            className="panel hud-corner p-6 md:p-8"
+            noValidate
+            onSubmit={(e) => {
+              e.preventDefault();
+              setSubmitted(true);
+            }}
+            aria-label="Request the DROM technical brief"
+          >
+            <div className="flex items-center justify-between mb-6">
+              <span className="label">BRIEF REQUEST FORM</span>
+              <span className="micro flex items-center gap-2 text-text-secondary">
+                <span className="h-1.5 w-1.5 rounded-full bg-signal-cyan animate-pulse-dim" />
+                SECURE
+              </span>
+            </div>
+
+            {submitted ? (
+              <div className="py-12 text-center">
+                <span className="micro text-signal-cyan">REQUEST RECEIVED</span>
+                <h3 className="mt-3 font-display text-h4 text-text-primary">
+                  Thank you. The product team will be in contact.
+                </h3>
+                <p className="mt-3 text-body text-text-secondary max-w-prose mx-auto">
+                  Your request has been logged for review. A response will follow with the
+                  technical brief and any next steps.
+                </p>
+              </div>
+            ) : (
+              <>
+                <div className="grid gap-5 md:grid-cols-2">
+                  <Field label="NAME" name="name" required />
+                  <Field label="ORGANIZATION" name="org" required />
+                  <Field label="ROLE" name="role" />
+                  <Field label="EMAIL" name="email" type="email" required />
+                  <Select label="AREA OF INTEREST" name="area" options={AREAS} />
+                  <Field label="COUNTRY" name="country" />
+                </div>
+
+                <Field
+                  label="MESSAGE"
+                  name="message"
+                  textarea
+                  className="mt-5"
+                  placeholder="Briefly describe the evaluation context."
+                />
+
+                <div className="mt-7 flex flex-col-reverse md:flex-row md:items-center md:justify-between gap-4">
+                  <p className="micro text-text-muted max-w-md">
+                    BY SUBMITTING, YOU ACKNOWLEDGE THIS IS A REQUEST. ACCESS TO THE TECHNICAL
+                    BRIEF IS REVIEWED ON A PER-CASE BASIS.
+                  </p>
+                  <div className="flex gap-3">
+                    <button type="button" className="btn-ghost">
+                      Contact Product Team
+                    </button>
+                    <button type="submit" className="btn-primary">
+                      Request Technical Brief
+                    </button>
+                  </div>
+                </div>
+              </>
+            )}
+          </form>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between border-b border-border-subtle py-3">
+      <span className="micro text-text-muted">{label}</span>
+      <span className="font-mono text-label text-text-primary">{value}</span>
+    </div>
+  );
+}
+
+interface FieldProps extends React.InputHTMLAttributes<HTMLInputElement & HTMLTextAreaElement> {
+  label: string;
+  textarea?: boolean;
+  className?: string;
+}
+
+function Field({ label, name, textarea = false, className = '', ...rest }: FieldProps) {
+  const id = `field-${name}`;
+  const cn =
+    'w-full bg-ink-950/70 border border-border-blue/40 focus:border-signal-blue/80 ' +
+    'focus:outline-none px-3 py-2.5 font-sans text-body text-text-primary placeholder:text-text-muted ' +
+    'rounded-sm transition-colors';
+  return (
+    <div className={className}>
+      <label htmlFor={id} className="micro text-text-muted mb-2 block">
+        {label}
+        {rest.required && <span className="text-signal-amber"> *</span>}
+      </label>
+      {textarea ? (
+        <textarea id={id} name={name} rows={4} className={cn} {...(rest as React.TextareaHTMLAttributes<HTMLTextAreaElement>)} />
+      ) : (
+        <input id={id} name={name} className={cn} {...rest} />
+      )}
+    </div>
+  );
+}
+
+function Select({ label, name, options }: { label: string; name: string; options: string[] }) {
+  const id = `field-${name}`;
+  return (
+    <div>
+      <label htmlFor={id} className="micro text-text-muted mb-2 block">
+        {label}
+      </label>
+      <select
+        id={id}
+        name={name}
+        className="w-full bg-ink-950/70 border border-border-blue/40 focus:border-signal-blue/80
+          focus:outline-none px-3 py-2.5 font-sans text-body text-text-primary rounded-sm
+          transition-colors"
+      >
+        {options.map((o) => (
+          <option key={o} value={o} className="bg-ink-900">
+            {o}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/drom/src/components/system/NoScriptFallback.tsx
+++ b/drom/src/components/system/NoScriptFallback.tsx
@@ -1,0 +1,20 @@
+/**
+ * Visible message for users without JavaScript. Provides direct access to
+ * the underlying static content sections that follow the cinematic stage.
+ */
+export function NoScriptFallback() {
+  return (
+    <noscript>
+      <div className="fixed top-16 left-0 right-0 z-50 bg-ink-900 border-y border-border-blue/30">
+        <div className="shell py-3 flex items-center justify-between gap-4">
+          <span className="micro text-text-secondary">
+            INTERACTIVE CINEMATIC REQUIRES JAVASCRIPT — STATIC PRODUCT INFORMATION IS AVAILABLE BELOW.
+          </span>
+          <a href="#overview" className="micro text-signal-cyan underline underline-offset-4">
+            VIEW OVERVIEW
+          </a>
+        </div>
+      </div>
+    </noscript>
+  );
+}

--- a/drom/src/components/system/SmoothScroll.tsx
+++ b/drom/src/components/system/SmoothScroll.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import Lenis from '@studio-freight/lenis';
+import { useReducedMotion } from '@/lib/useReducedMotion';
+
+export function SmoothScroll({ children }: { children: React.ReactNode }) {
+  const reduced = useReducedMotion();
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (reduced) return;
+    const lenis = new Lenis({
+      duration: 1.15,
+      easing: (t) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
+      wheelMultiplier: 1,
+      touchMultiplier: 1.2,
+      smoothWheel: true,
+      lerp: 0.1,
+    });
+
+    const raf = (time: number) => {
+      lenis.raf(time);
+      rafRef.current = requestAnimationFrame(raf);
+    };
+    rafRef.current = requestAnimationFrame(raf);
+
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      lenis.destroy();
+    };
+  }, [reduced]);
+
+  return <>{children}</>;
+}

--- a/drom/src/components/three/CinematicStage.tsx
+++ b/drom/src/components/three/CinematicStage.tsx
@@ -89,24 +89,20 @@ export function CinematicStage() {
   const reduced = cap.reducedMotion;
 
   return (
-    <div ref={stageRef} className="relative" style={{ height: reduced ? 'auto' : '700vh' }}>
+    <div ref={stageRef} className="relative" style={{ height: reduced ? 'auto' : '900vh' }}>
       <div
         ref={stickyRef}
         className="relative h-screen w-full overflow-hidden"
       >
-        {/* Background grids */}
-        <div className="absolute inset-0 grid-overlay opacity-[0.18]" aria-hidden />
-        <div
-          className="absolute inset-0 bg-radial-fade pointer-events-none"
-          aria-hidden
-        />
-        {/* Vignette */}
+        {/* Subtle background grid — much fainter now, lets the drone dominate */}
+        <div className="absolute inset-0 grid-overlay opacity-[0.06]" aria-hidden />
+        {/* Vignette — heavier so light pools on the drone */}
         <div
           className="absolute inset-0 pointer-events-none"
           aria-hidden
           style={{
             background:
-              'radial-gradient(ellipse at center, transparent 50%, rgba(0,0,0,0.78) 100%)',
+              'radial-gradient(ellipse 70% 60% at center, transparent 30%, rgba(0,0,0,0.55) 75%, rgba(0,0,0,0.92) 100%)',
           }}
         />
 

--- a/drom/src/components/three/CinematicStage.tsx
+++ b/drom/src/components/three/CinematicStage.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import dynamic from 'next/dynamic';
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+import { useSceneState, PHASES } from './sceneState';
+import { useDeviceCapability } from '@/lib/useDeviceCapability';
+import { LoadingState } from '@/components/ui/LoadingState';
+import { CinematicHUD } from '@/components/cinematic/CinematicHUD';
+import { CinematicOverlay } from '@/components/cinematic/CinematicOverlay';
+import { StaticDronePoster } from '@/components/three/StaticDronePoster';
+
+const DroneScene = dynamic(
+  () => import('./DroneScene').then((m) => m.DroneScene),
+  { ssr: false, loading: () => <LoadingState progress={0.4} /> },
+);
+
+/**
+ * Pins a 3D scene and maps its scroll-bound `progress` 0..1 to camera/drone state.
+ * The pinned section is ~7 viewport heights tall — gives the impression of a long
+ * cinematic frame sequence while only running real-time rendering.
+ */
+export function CinematicStage() {
+  const stageRef = useRef<HTMLDivElement>(null);
+  const stickyRef = useRef<HTMLDivElement>(null);
+  const setProgress = useSceneState((s) => s.setProgress);
+  const setPhase = useSceneState((s) => s.setPhase);
+  const ready = useSceneState((s) => s.ready);
+  const cap = useDeviceCapability();
+  const [bootProgress, setBootProgress] = useState(0);
+
+  // Soft boot animation while WebGL warms up
+  useEffect(() => {
+    if (ready) {
+      setBootProgress(1);
+      return;
+    }
+    let raf = 0;
+    const start = performance.now();
+    const tick = () => {
+      const elapsed = performance.now() - start;
+      const eased = Math.min(0.92, elapsed / 1800);
+      setBootProgress(eased);
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [ready]);
+
+  useEffect(() => {
+    if (cap.reducedMotion) return;
+    if (!stageRef.current) return;
+
+    gsap.registerPlugin(ScrollTrigger);
+
+    const ctx = gsap.context(() => {
+      const scrubVal = cap.tier === 'low' ? 0.6 : 0.8;
+      const stage = stageRef.current!;
+      const sticky = stickyRef.current!;
+
+      const trigger = ScrollTrigger.create({
+        trigger: stage,
+        start: 'top top',
+        end: 'bottom bottom',
+        pin: sticky,
+        pinSpacing: false,
+        scrub: scrubVal,
+        invalidateOnRefresh: true,
+        onUpdate: (self) => {
+          const p = self.progress;
+          setProgress(p);
+          // determine phase
+          let phase = 0;
+          for (let i = 0; i < PHASES.length; i++) {
+            if (p >= PHASES[i].t) phase = i;
+          }
+          setPhase(phase);
+        },
+      });
+
+      return () => trigger.kill();
+    }, stageRef);
+
+    return () => ctx.revert();
+  }, [cap.reducedMotion, cap.tier, setProgress, setPhase]);
+
+  // For reduced motion, render a static poster + use anchor scroll as phase driver
+  const reduced = cap.reducedMotion;
+
+  return (
+    <div ref={stageRef} className="relative" style={{ height: reduced ? 'auto' : '700vh' }}>
+      <div
+        ref={stickyRef}
+        className="relative h-screen w-full overflow-hidden"
+      >
+        {/* Background grids */}
+        <div className="absolute inset-0 grid-overlay opacity-[0.18]" aria-hidden />
+        <div
+          className="absolute inset-0 bg-radial-fade pointer-events-none"
+          aria-hidden
+        />
+        {/* Vignette */}
+        <div
+          className="absolute inset-0 pointer-events-none"
+          aria-hidden
+          style={{
+            background:
+              'radial-gradient(ellipse at center, transparent 50%, rgba(0,0,0,0.78) 100%)',
+          }}
+        />
+
+        {/* WebGL scene OR static poster */}
+        <div className="absolute inset-0">
+          {cap.webgl && !reduced ? (
+            <DroneScene className="absolute inset-0 h-full w-full" />
+          ) : (
+            <StaticDronePoster />
+          )}
+          {!ready && cap.webgl && !reduced && <LoadingState progress={bootProgress} />}
+        </div>
+
+        {/* HUD overlay (telemetry corners, scan line, phase marker) */}
+        <CinematicHUD />
+
+        {/* Phase-dependent text overlay (hero copy, spec panel, callouts, etc.) */}
+        <CinematicOverlay />
+      </div>
+    </div>
+  );
+}

--- a/drom/src/components/three/DroneModel.tsx
+++ b/drom/src/components/three/DroneModel.tsx
@@ -1,0 +1,293 @@
+'use client';
+
+import { forwardRef, useMemo, useRef } from 'react';
+import { Group, MeshStandardMaterial, MeshPhysicalMaterial } from 'three';
+import { useFrame } from '@react-three/fiber';
+import { Float } from '@react-three/drei';
+
+interface DroneModelProps {
+  spinProps?: boolean;
+  hover?: boolean;
+}
+
+/**
+ * Procedural tactical FPV-style drone.
+ * Compact graphite frame, 4 arms with motors and props, central housing,
+ * top dome antenna, front camera, and small whip antennas.
+ * Built from primitives for performance — no external GLB required.
+ */
+export const DroneModel = forwardRef<Group, DroneModelProps>(function DroneModel(
+  { spinProps = true, hover = true },
+  ref,
+) {
+  const propRefs = useRef<Group[]>([]);
+  const innerRef = useRef<Group>(null!);
+
+  const matBody = useMemo(
+    () =>
+      new MeshPhysicalMaterial({
+        color: 0x12161c,
+        metalness: 0.55,
+        roughness: 0.55,
+        clearcoat: 0.25,
+        clearcoatRoughness: 0.7,
+        sheen: 0.05,
+      }),
+    [],
+  );
+  const matAccent = useMemo(
+    () =>
+      new MeshStandardMaterial({
+        color: 0x1d2230,
+        metalness: 0.7,
+        roughness: 0.4,
+      }),
+    [],
+  );
+  const matMetal = useMemo(
+    () =>
+      new MeshStandardMaterial({
+        color: 0x22262d,
+        metalness: 0.95,
+        roughness: 0.28,
+      }),
+    [],
+  );
+  const matCoil = useMemo(
+    () =>
+      new MeshStandardMaterial({
+        color: 0x6b3a1c,
+        metalness: 0.85,
+        roughness: 0.45,
+      }),
+    [],
+  );
+  const matLens = useMemo(
+    () =>
+      new MeshPhysicalMaterial({
+        color: 0x05080d,
+        metalness: 0.2,
+        roughness: 0.05,
+        clearcoat: 1,
+        clearcoatRoughness: 0.05,
+        transmission: 0.05,
+      }),
+    [],
+  );
+  const matDome = useMemo(
+    () =>
+      new MeshStandardMaterial({
+        color: 0x0d1118,
+        metalness: 0.4,
+        roughness: 0.65,
+      }),
+    [],
+  );
+  const matLED = useMemo(
+    () =>
+      new MeshStandardMaterial({
+        color: 0x1d6fff,
+        emissive: 0x1d6fff,
+        emissiveIntensity: 1.2,
+        metalness: 0,
+        roughness: 0.2,
+      }),
+    [],
+  );
+  const matProp = useMemo(
+    () =>
+      new MeshStandardMaterial({
+        color: 0x0a0d12,
+        metalness: 0.1,
+        roughness: 0.85,
+        transparent: true,
+        opacity: 0.95,
+      }),
+    [],
+  );
+
+  useFrame((_, delta) => {
+    if (spinProps) {
+      const speed = 38 * delta;
+      propRefs.current.forEach((p, i) => {
+        if (p) p.rotation.y += i % 2 === 0 ? speed : -speed;
+      });
+    }
+  });
+
+  // Arm endpoints (X-shape, slightly offset arms = compact tactical look)
+  const arms = [
+    { x: 1, z: 1 },
+    { x: -1, z: 1 },
+    { x: -1, z: -1 },
+    { x: 1, z: -1 },
+  ];
+  const armReach = 0.95;
+
+  return (
+    <Float
+      speed={hover ? 1.2 : 0}
+      floatIntensity={hover ? 0.3 : 0}
+      rotationIntensity={hover ? 0.05 : 0}
+    >
+      <group ref={ref}>
+        <group ref={innerRef} rotation={[0, 0, 0]} scale={1}>
+          {/* Lower belly plate */}
+          <mesh position={[0, -0.15, 0]} castShadow receiveShadow material={matBody}>
+            <boxGeometry args={[1.2, 0.06, 1.0]} />
+          </mesh>
+
+          {/* Mid carbon plate */}
+          <mesh position={[0, 0.0, 0]} castShadow receiveShadow material={matAccent}>
+            <boxGeometry args={[1.4, 0.04, 0.6]} />
+          </mesh>
+
+          {/* Central electronics housing */}
+          <mesh position={[0, 0.18, 0]} castShadow receiveShadow material={matBody}>
+            <boxGeometry args={[0.7, 0.32, 0.55]} />
+          </mesh>
+          {/* Housing top inset */}
+          <mesh position={[0, 0.36, 0]} castShadow receiveShadow material={matAccent}>
+            <boxGeometry args={[0.55, 0.04, 0.42]} />
+          </mesh>
+          {/* Heat-sink fins (subtle detail) */}
+          {Array.from({ length: 6 }).map((_, i) => (
+            <mesh
+              key={i}
+              position={[-0.32 + i * 0.13, 0.18, 0.29]}
+              material={matMetal}
+              castShadow
+            >
+              <boxGeometry args={[0.05, 0.22, 0.02]} />
+            </mesh>
+          ))}
+
+          {/* Top dome antenna (signature element from product photo) */}
+          <group position={[0, 0.55, -0.05]}>
+            <mesh material={matMetal} castShadow>
+              <cylinderGeometry args={[0.04, 0.04, 0.22, 16]} />
+            </mesh>
+            <mesh position={[0, 0.18, 0]} material={matDome} castShadow>
+              <sphereGeometry args={[0.32, 32, 24, 0, Math.PI * 2, 0, Math.PI / 2]} />
+            </mesh>
+            {/* Dome inner rim */}
+            <mesh position={[0, 0.18, 0]} material={matAccent}>
+              <torusGeometry args={[0.32, 0.015, 8, 32]} />
+            </mesh>
+          </group>
+
+          {/* Front camera turret */}
+          <group position={[0, 0.18, 0.32]}>
+            <mesh material={matBody} castShadow>
+              <boxGeometry args={[0.22, 0.22, 0.18]} />
+            </mesh>
+            <mesh position={[0, 0, 0.1]} rotation={[Math.PI / 2, 0, 0]} material={matMetal}>
+              <cylinderGeometry args={[0.07, 0.08, 0.04, 24]} />
+            </mesh>
+            <mesh position={[0, 0, 0.13]} rotation={[Math.PI / 2, 0, 0]} material={matLens}>
+              <cylinderGeometry args={[0.055, 0.055, 0.02, 24]} />
+            </mesh>
+            {/* Status LED */}
+            <mesh position={[0.08, 0.07, 0.1]} material={matLED}>
+              <sphereGeometry args={[0.012, 8, 8]} />
+            </mesh>
+          </group>
+
+          {/* Whip antennas */}
+          {[
+            { x: 0.4, z: -0.2, tilt: 0.25 },
+            { x: -0.4, z: -0.2, tilt: -0.25 },
+          ].map((a, i) => (
+            <group key={i} position={[a.x, 0.32, a.z]} rotation={[0, 0, a.tilt]}>
+              <mesh material={matMetal}>
+                <cylinderGeometry args={[0.008, 0.012, 0.45, 8]} />
+              </mesh>
+              <mesh position={[0, 0.24, 0]} material={matAccent}>
+                <sphereGeometry args={[0.018, 8, 8]} />
+              </mesh>
+            </group>
+          ))}
+
+          {/* Landing skids */}
+          {[
+            { x: 0.45, z: 0 },
+            { x: -0.45, z: 0 },
+          ].map((s, i) => (
+            <group key={i} position={[s.x, -0.32, 0]}>
+              <mesh material={matAccent}>
+                <boxGeometry args={[0.02, 0.18, 0.5]} />
+              </mesh>
+              <mesh position={[0, -0.09, 0]} material={matAccent}>
+                <boxGeometry args={[0.03, 0.02, 0.62]} />
+              </mesh>
+            </group>
+          ))}
+
+          {/* Arms + motors + propellers */}
+          {arms.map((a, i) => {
+            const ax = a.x * armReach;
+            const az = a.z * armReach;
+            const angle = Math.atan2(az, ax);
+            return (
+              <group key={i}>
+                {/* Arm */}
+                <group position={[ax / 2, -0.05, az / 2]} rotation={[0, -angle, 0]}>
+                  <mesh material={matBody} castShadow>
+                    <boxGeometry args={[Math.hypot(ax, az), 0.06, 0.12]} />
+                  </mesh>
+                  {/* arm fin underside */}
+                  <mesh position={[0, -0.06, 0]} material={matAccent}>
+                    <boxGeometry args={[Math.hypot(ax, az) * 0.7, 0.02, 0.06]} />
+                  </mesh>
+                </group>
+
+                {/* Motor stack at arm tip */}
+                <group position={[ax, 0.02, az]}>
+                  <mesh position={[0, 0.05, 0]} material={matMetal} castShadow>
+                    <cylinderGeometry args={[0.12, 0.12, 0.1, 24]} />
+                  </mesh>
+                  {/* coil ring (warm metallic accent) */}
+                  <mesh position={[0, 0.085, 0]} material={matCoil}>
+                    <torusGeometry args={[0.1, 0.018, 8, 24]} />
+                  </mesh>
+                  <mesh position={[0, 0.12, 0]} material={matMetal}>
+                    <cylinderGeometry args={[0.05, 0.05, 0.05, 16]} />
+                  </mesh>
+                  {/* Bullnose prop guard nub */}
+                  <mesh position={[0, 0.16, 0]} material={matAccent}>
+                    <cylinderGeometry args={[0.02, 0.025, 0.04, 12]} />
+                  </mesh>
+
+                  {/* Propeller — 3 blades */}
+                  <group ref={(el) => { if (el) propRefs.current[i] = el; }} position={[0, 0.18, 0]}>
+                    {[0, (Math.PI * 2) / 3, (Math.PI * 4) / 3].map((r, j) => (
+                      <mesh
+                        key={j}
+                        rotation={[0, r, 0]}
+                        position={[0, 0, 0]}
+                        material={matProp}
+                      >
+                        <boxGeometry args={[0.42, 0.012, 0.05]} />
+                      </mesh>
+                    ))}
+                    {/* Hub */}
+                    <mesh material={matAccent}>
+                      <cylinderGeometry args={[0.035, 0.035, 0.025, 12]} />
+                    </mesh>
+                  </group>
+                </group>
+              </group>
+            );
+          })}
+
+          {/* Subtle bottom rim LEDs */}
+          {arms.map((a, i) => (
+            <mesh key={i} position={[a.x * 0.5, -0.18, a.z * 0.5]} material={matLED}>
+              <sphereGeometry args={[0.012, 8, 8]} />
+            </mesh>
+          ))}
+        </group>
+      </group>
+    </Float>
+  );
+});

--- a/drom/src/components/three/DroneModel.tsx
+++ b/drom/src/components/three/DroneModel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { forwardRef, useMemo, useRef } from 'react';
+import { forwardRef, useMemo, useRef, MutableRefObject } from 'react';
 import { Group, MeshStandardMaterial, MeshPhysicalMaterial } from 'three';
 import { useFrame } from '@react-three/fiber';
 import { Float } from '@react-three/drei';
@@ -8,6 +8,8 @@ import { Float } from '@react-three/drei';
 interface DroneModelProps {
   spinProps?: boolean;
   hover?: boolean;
+  /** 0..1 — drives prop spin speed and accent intensity */
+  propEnergyRef?: MutableRefObject<number>;
 }
 
 /**
@@ -17,7 +19,7 @@ interface DroneModelProps {
  * Built from primitives for performance — no external GLB required.
  */
 export const DroneModel = forwardRef<Group, DroneModelProps>(function DroneModel(
-  { spinProps = true, hover = true },
+  { spinProps = true, hover = true, propEnergyRef },
   ref,
 ) {
   const propRefs = useRef<Group[]>([]);
@@ -107,12 +109,13 @@ export const DroneModel = forwardRef<Group, DroneModelProps>(function DroneModel
   );
 
   useFrame((_, delta) => {
-    if (spinProps) {
-      const speed = 38 * delta;
-      propRefs.current.forEach((p, i) => {
-        if (p) p.rotation.y += i % 2 === 0 ? speed : -speed;
-      });
-    }
+    if (!spinProps) return;
+    // Energy 0..1 → 6..70 rad/s. Idle = lazy spool, mid = combat-ready, high = blur.
+    const energy = propEnergyRef?.current ?? 0.6;
+    const speed = (6 + energy * 64) * delta;
+    propRefs.current.forEach((p, i) => {
+      if (p) p.rotation.y += i % 2 === 0 ? speed : -speed;
+    });
   });
 
   // Arm endpoints (X-shape, slightly offset arms = compact tactical look)

--- a/drom/src/components/three/DroneScene.tsx
+++ b/drom/src/components/three/DroneScene.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { Suspense, useMemo, useRef } from 'react';
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { Environment, ContactShadows, AdaptiveDpr, AdaptiveEvents, PerformanceMonitor } from '@react-three/drei';
+import * as THREE from 'three';
+import { DroneModel } from './DroneModel';
+import { useSceneState } from './sceneState';
+import { useDeviceCapability } from '@/lib/useDeviceCapability';
+
+/** Smooth lerp utility (frame-rate independent) */
+const damp = (current: number, target: number, lambda: number, dt: number) =>
+  THREE.MathUtils.damp(current, target, lambda, dt);
+
+/**
+ * Camera + drone choreography keyed to scene `progress` (0..1).
+ * Uses interpolation only — feels like ~10k frames without loading any.
+ */
+function Choreography({ tier }: { tier: ReturnType<typeof useDeviceCapability>['tier'] }) {
+  const { camera } = useThree();
+  const droneRef = useRef<THREE.Group>(null!);
+  const targetRef = useRef(new THREE.Vector3(0, 0, 0));
+  const desiredCamPos = useRef(new THREE.Vector3(0, 0.4, 4.2));
+  const desiredCamTarget = useRef(new THREE.Vector3(0, 0, 0));
+  const desiredDroneRot = useRef(new THREE.Euler(0, 0, 0));
+  const desiredDronePos = useRef(new THREE.Vector3(0, 0, 0));
+
+  useFrame((state, dt) => {
+    const p = useSceneState.getState().progress;
+
+    // ===== Camera path =====
+    // Phase 1 (0.00–0.14): far, low key-light, slight downward angle
+    // Phase 2 (0.14–0.30): approach + reveal
+    // Phase 3 (0.30–0.50): inspection orbit
+    // Phase 4 (0.50–0.66): drone shifts left, spec panel space on right
+    // Phase 5 (0.66–0.80): three-quarter feature mapping
+    // Phase 6 (0.80–0.92): pull back, drone smaller, command interface space
+    // Phase 7 (0.92–1.00): centered final lockup
+
+    let camX = 0,
+      camY = 0.4,
+      camZ = 4.2;
+    let tgtX = 0,
+      tgtY = 0,
+      tgtZ = 0;
+    let droneRotY = 0;
+    let droneX = 0;
+    let droneScale = 1;
+
+    if (p < 0.14) {
+      const k = p / 0.14;
+      camZ = lerp(5.6, 3.6, ease(k));
+      camY = lerp(0.1, 0.45, k);
+      droneRotY = lerp(-0.3, -0.1, k);
+    } else if (p < 0.3) {
+      const k = (p - 0.14) / (0.3 - 0.14);
+      camZ = lerp(3.6, 2.6, ease(k));
+      camY = lerp(0.45, 0.5, k);
+      droneRotY = lerp(-0.1, 0.2, k);
+    } else if (p < 0.5) {
+      const k = (p - 0.3) / (0.5 - 0.3);
+      // Inspection orbit
+      const angle = lerp(0, Math.PI * 1.2, k);
+      camX = Math.sin(angle) * 2.6;
+      camZ = Math.cos(angle) * 2.6;
+      camY = lerp(0.5, 0.65, k);
+      droneRotY = lerp(0.2, 0.6, k);
+    } else if (p < 0.66) {
+      const k = (p - 0.5) / (0.66 - 0.5);
+      // Spec lock — drone shifts visually left so right column reads
+      const angle = lerp(Math.PI * 1.2, Math.PI * 0.85, k);
+      camX = Math.sin(angle) * 2.4;
+      camZ = Math.cos(angle) * 2.4;
+      camY = lerp(0.65, 0.4, k);
+      droneRotY = lerp(0.6, 0.3, k);
+      droneX = lerp(0, -0.5, k);
+    } else if (p < 0.8) {
+      const k = (p - 0.66) / (0.8 - 0.66);
+      // Three-quarter feature mapping
+      camX = lerp(2.0, 1.6, k);
+      camZ = lerp(2.0, 2.4, k);
+      camY = lerp(0.4, 0.45, k);
+      droneRotY = lerp(0.3, 0.5, k);
+      droneX = lerp(-0.5, 0, k);
+    } else if (p < 0.92) {
+      const k = (p - 0.8) / (0.92 - 0.8);
+      // Command interface — pull back, drone smaller
+      camX = lerp(1.6, 0.8, k);
+      camZ = lerp(2.4, 4.4, k);
+      camY = lerp(0.45, 0.7, k);
+      droneRotY = lerp(0.5, 0.1, k);
+      droneScale = lerp(1, 0.78, k);
+    } else {
+      const k = (p - 0.92) / (1 - 0.92);
+      // Lockup
+      camX = lerp(0.8, 0.2, k);
+      camZ = lerp(4.4, 3.4, k);
+      camY = lerp(0.7, 0.45, k);
+      droneRotY = lerp(0.1, -0.05, k);
+      droneScale = lerp(0.78, 1, k);
+    }
+
+    desiredCamPos.current.set(camX, camY, camZ);
+    desiredCamTarget.current.set(tgtX, tgtY, tgtZ);
+    desiredDroneRot.current.set(0, droneRotY, 0);
+    desiredDronePos.current.set(droneX, 0, 0);
+
+    const lambda = tier === 'low' ? 4.5 : 6.5;
+    camera.position.x = damp(camera.position.x, desiredCamPos.current.x, lambda, dt);
+    camera.position.y = damp(camera.position.y, desiredCamPos.current.y, lambda, dt);
+    camera.position.z = damp(camera.position.z, desiredCamPos.current.z, lambda, dt);
+
+    targetRef.current.x = damp(targetRef.current.x, desiredCamTarget.current.x, lambda, dt);
+    targetRef.current.y = damp(targetRef.current.y, desiredCamTarget.current.y, lambda, dt);
+    targetRef.current.z = damp(targetRef.current.z, desiredCamTarget.current.z, lambda, dt);
+    camera.lookAt(targetRef.current);
+
+    if (droneRef.current) {
+      droneRef.current.rotation.y = damp(
+        droneRef.current.rotation.y,
+        desiredDroneRot.current.y,
+        lambda,
+        dt,
+      );
+      droneRef.current.position.x = damp(
+        droneRef.current.position.x,
+        desiredDronePos.current.x,
+        lambda,
+        dt,
+      );
+      const targetScale = droneScale;
+      const cur = droneRef.current.scale.x;
+      const ns = damp(cur, targetScale, lambda, dt);
+      droneRef.current.scale.setScalar(ns);
+    }
+
+    // Idle subtle drift on camera so the scene never feels static
+    const t = state.clock.elapsedTime;
+    camera.position.x += Math.sin(t * 0.3) * 0.01;
+    camera.position.y += Math.cos(t * 0.4) * 0.006;
+  });
+
+  return (
+    <group ref={droneRef}>
+      <DroneModel spinProps={tier !== 'low'} hover={tier !== 'low'} />
+    </group>
+  );
+}
+
+function lerp(a: number, b: number, t: number) {
+  return a + (b - a) * t;
+}
+function ease(t: number) {
+  return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+}
+
+function StudioLighting({ tier }: { tier: ReturnType<typeof useDeviceCapability>['tier'] }) {
+  return (
+    <>
+      <ambientLight intensity={0.18} color="#1a2030" />
+      {/* Key light */}
+      <spotLight
+        position={[3, 5, 4]}
+        angle={0.55}
+        penumbra={0.85}
+        intensity={1.4}
+        color="#dbe6ff"
+        castShadow={tier === 'high'}
+        shadow-mapSize-width={tier === 'high' ? 1024 : 512}
+        shadow-mapSize-height={tier === 'high' ? 1024 : 512}
+      />
+      {/* Blue rim */}
+      <directionalLight position={[-4, 2, -3]} intensity={0.9} color="#1d6fff" />
+      {/* Subtle top accent */}
+      <directionalLight position={[0, 6, 0]} intensity={0.35} color="#00aeef" />
+      {/* Fill */}
+      <pointLight position={[0, -2, 3]} intensity={0.25} color="#2b3a55" />
+    </>
+  );
+}
+
+interface DroneSceneProps {
+  className?: string;
+}
+
+export function DroneScene({ className }: DroneSceneProps) {
+  const cap = useDeviceCapability();
+  const dpr = useMemo<[number, number]>(() => [1, Math.min(cap.dpr, cap.tier === 'low' ? 1.2 : 1.75)], [cap.dpr, cap.tier]);
+  const setReady = useSceneState((s) => s.setReady);
+
+  return (
+    <div className={className}>
+      <Canvas
+        camera={{ position: [0, 0.4, 4.2], fov: 32, near: 0.1, far: 50 }}
+        dpr={dpr}
+        gl={{
+          antialias: true,
+          powerPreference: 'high-performance',
+          alpha: true,
+          stencil: false,
+        }}
+        onCreated={({ gl, scene }) => {
+          gl.setClearColor(0x000000, 0);
+          scene.fog = new THREE.Fog(0x030508, 7, 18);
+          setReady(true);
+        }}
+        shadows={cap.tier === 'high'}
+      >
+        <PerformanceMonitor />
+        <AdaptiveDpr pixelated />
+        <AdaptiveEvents />
+
+        <Suspense fallback={null}>
+          <StudioLighting tier={cap.tier} />
+          {cap.tier !== 'low' && <Environment preset="warehouse" environmentIntensity={0.18} />}
+
+          <Choreography tier={cap.tier} />
+
+          {/* Soft contact shadow under the drone */}
+          <ContactShadows
+            position={[0, -0.42, 0]}
+            opacity={0.55}
+            scale={6}
+            blur={2.4}
+            far={2.6}
+            color="#000000"
+            resolution={cap.tier === 'high' ? 512 : 256}
+          />
+        </Suspense>
+      </Canvas>
+    </div>
+  );
+}

--- a/drom/src/components/three/DroneScene.tsx
+++ b/drom/src/components/three/DroneScene.tsx
@@ -2,180 +2,285 @@
 
 import { Suspense, useMemo, useRef } from 'react';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
-import { Environment, ContactShadows, AdaptiveDpr, AdaptiveEvents, PerformanceMonitor } from '@react-three/drei';
+import {
+  Environment,
+  ContactShadows,
+  AdaptiveDpr,
+  AdaptiveEvents,
+  PerformanceMonitor,
+  Sparkles,
+} from '@react-three/drei';
 import * as THREE from 'three';
 import { DroneModel } from './DroneModel';
 import { useSceneState } from './sceneState';
 import { useDeviceCapability } from '@/lib/useDeviceCapability';
 
-/** Smooth lerp utility (frame-rate independent) */
 const damp = (current: number, target: number, lambda: number, dt: number) =>
   THREE.MathUtils.damp(current, target, lambda, dt);
+const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+const ease = (t: number) => (t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2);
+const easeOut = (t: number) => 1 - Math.pow(1 - t, 3);
 
 /**
- * Camera + drone choreography keyed to scene `progress` (0..1).
- * Uses interpolation only — feels like ~10k frames without loading any.
+ * Phase choreography — keyframes for camera and drone.
+ * All values interpolate continuously; transitions are dramatic but never disorienting.
  */
+interface Pose {
+  cam: THREE.Vector3;
+  tgt: THREE.Vector3;
+  /** drone yaw, pitch, bank (radians) */
+  rot: THREE.Vector3;
+  pos: THREE.Vector3;
+  scale: number;
+  /** 0..1, used to drive prop spin speed and key-light intensity */
+  energy: number;
+  fov: number;
+}
+
+function pose(
+  cam: [number, number, number],
+  tgt: [number, number, number],
+  rot: [number, number, number],
+  pos: [number, number, number],
+  scale: number,
+  energy: number,
+  fov: number,
+): Pose {
+  return {
+    cam: new THREE.Vector3(...cam),
+    tgt: new THREE.Vector3(...tgt),
+    rot: new THREE.Vector3(...rot),
+    pos: new THREE.Vector3(...pos),
+    scale,
+    energy,
+    fov,
+  };
+}
+
 function Choreography({ tier }: { tier: ReturnType<typeof useDeviceCapability>['tier'] }) {
   const { camera } = useThree();
   const droneRef = useRef<THREE.Group>(null!);
-  const targetRef = useRef(new THREE.Vector3(0, 0, 0));
-  const desiredCamPos = useRef(new THREE.Vector3(0, 0.4, 4.2));
-  const desiredCamTarget = useRef(new THREE.Vector3(0, 0, 0));
-  const desiredDroneRot = useRef(new THREE.Euler(0, 0, 0));
-  const desiredDronePos = useRef(new THREE.Vector3(0, 0, 0));
+  const lookAtRef = useRef(new THREE.Vector3(0, 0, 0));
+  const energyRef = useRef(0);
+  const propEnergyRef = useRef(0);
+
+  // Working pose (mutated each frame) and tmp pose for orbit math
+  const working = useMemo<Pose>(
+    () => pose([0, 0, 8], [0, 0, 0], [0, 0, 0], [0, 0, 0], 1, 0, 32),
+    [],
+  );
 
   useFrame((state, dt) => {
     const p = useSceneState.getState().progress;
+    const t = state.clock.elapsedTime;
 
-    // ===== Camera path =====
-    // Phase 1 (0.00–0.14): far, low key-light, slight downward angle
-    // Phase 2 (0.14–0.30): approach + reveal
-    // Phase 3 (0.30–0.50): inspection orbit
-    // Phase 4 (0.50–0.66): drone shifts left, spec panel space on right
-    // Phase 5 (0.66–0.80): three-quarter feature mapping
-    // Phase 6 (0.80–0.92): pull back, drone smaller, command interface space
-    // Phase 7 (0.92–1.00): centered final lockup
+    // ===== Build target pose for current scroll =====
+    let camX = 0, camY = 0, camZ = 8;
+    let tgtX = 0, tgtY = 0, tgtZ = 0;
+    let yaw = 0, pitch = 0, bank = 0;
+    let dx = 0, dy = 0, dz = 0;
+    let scale = 1;
+    let energy = 0;
+    let fov = 30;
 
-    let camX = 0,
-      camY = 0.4,
-      camZ = 4.2;
-    let tgtX = 0,
-      tgtY = 0,
-      tgtZ = 0;
-    let droneRotY = 0;
-    let droneX = 0;
-    let droneScale = 1;
-
-    if (p < 0.14) {
-      const k = p / 0.14;
-      camZ = lerp(5.6, 3.6, ease(k));
+    if (p < 0.10) {
+      // PHASE 1 — WAKE: deep darkness, drone barely visible, slowly emerges
+      const k = p / 0.10;
+      camZ = lerp(9, 6.5, easeOut(k));
+      camY = lerp(-0.2, 0.1, k);
+      camX = lerp(-0.3, 0.1, k);
+      pitch = lerp(0.18, 0.05, k); // slight upward look (drone seen from below)
+      energy = lerp(0, 0.15, k);
+      fov = lerp(38, 34, k);
+    } else if (p < 0.22) {
+      // PHASE 2 — IGNITION: dolly forward, drone tilts forward, props ramp up
+      const k = (p - 0.10) / (0.22 - 0.10);
+      camZ = lerp(6.5, 3.6, easeOut(k));
       camY = lerp(0.1, 0.45, k);
-      droneRotY = lerp(-0.3, -0.1, k);
-    } else if (p < 0.3) {
-      const k = (p - 0.14) / (0.3 - 0.14);
-      camZ = lerp(3.6, 2.6, ease(k));
-      camY = lerp(0.45, 0.5, k);
-      droneRotY = lerp(-0.1, 0.2, k);
-    } else if (p < 0.5) {
-      const k = (p - 0.3) / (0.5 - 0.3);
-      // Inspection orbit
-      const angle = lerp(0, Math.PI * 1.2, k);
-      camX = Math.sin(angle) * 2.6;
-      camZ = Math.cos(angle) * 2.6;
-      camY = lerp(0.5, 0.65, k);
-      droneRotY = lerp(0.2, 0.6, k);
+      camX = lerp(0.1, 0, k);
+      pitch = lerp(0.05, -0.18, k); // pitch FORWARD as if powering up
+      bank = Math.sin(t * 0.8) * 0.04;
+      energy = lerp(0.15, 0.85, k);
+      fov = lerp(34, 30, k);
+    } else if (p < 0.45) {
+      // PHASE 3 — FULL ORBIT: 720° around drone, with vertical wave
+      const k = (p - 0.22) / (0.45 - 0.22);
+      const angle = lerp(0, Math.PI * 2.0, ease(k)); // 720° — really wraps around
+      const radius = lerp(3.6, 2.6, k);
+      camX = Math.sin(angle) * radius;
+      camZ = Math.cos(angle) * radius;
+      camY = lerp(0.45, 0.65, k) + Math.sin(k * Math.PI) * 0.4; // dip + rise
+      pitch = lerp(-0.18, -0.06, k);
+      bank = Math.sin(angle) * 0.12; // drone banks INTO the orbit
+      yaw = -angle * 0.15; // counter-rotate slightly
+      energy = 0.95;
+      fov = lerp(30, 28, k);
+    } else if (p < 0.55) {
+      // PHASE 4 — MACRO: dive close to camera turret, see the lens
+      const k = (p - 0.45) / (0.55 - 0.45);
+      camX = lerp(0, 0.4, easeOut(k));
+      camY = lerp(0.65, 0.25, k);
+      camZ = lerp(2.6, 1.4, easeOut(k));
+      tgtZ = lerp(0, 0.25, k); // look at the front of the drone
+      tgtY = lerp(0, 0.18, k);
+      pitch = lerp(-0.06, 0, k);
+      bank = 0;
+      yaw = lerp(0, 0.15, k);
+      energy = 0.9;
+      fov = lerp(28, 24, k); // tighter focal length for macro
     } else if (p < 0.66) {
-      const k = (p - 0.5) / (0.66 - 0.5);
-      // Spec lock — drone shifts visually left so right column reads
-      const angle = lerp(Math.PI * 1.2, Math.PI * 0.85, k);
-      camX = Math.sin(angle) * 2.4;
-      camZ = Math.cos(angle) * 2.4;
-      camY = lerp(0.65, 0.4, k);
-      droneRotY = lerp(0.6, 0.3, k);
-      droneX = lerp(0, -0.5, k);
-    } else if (p < 0.8) {
-      const k = (p - 0.66) / (0.8 - 0.66);
-      // Three-quarter feature mapping
-      camX = lerp(2.0, 1.6, k);
-      camZ = lerp(2.0, 2.4, k);
-      camY = lerp(0.4, 0.45, k);
-      droneRotY = lerp(0.3, 0.5, k);
-      droneX = lerp(-0.5, 0, k);
-    } else if (p < 0.92) {
-      const k = (p - 0.8) / (0.92 - 0.8);
-      // Command interface — pull back, drone smaller
-      camX = lerp(1.6, 0.8, k);
-      camZ = lerp(2.4, 4.4, k);
-      camY = lerp(0.45, 0.7, k);
-      droneRotY = lerp(0.5, 0.1, k);
-      droneScale = lerp(1, 0.78, k);
+      // PHASE 5 — SPECIFICATION LOCK: profile shot, drone shifts left
+      const k = (p - 0.55) / (0.66 - 0.55);
+      camX = lerp(0.4, 2.4, ease(k));
+      camY = lerp(0.25, 0.45, k);
+      camZ = lerp(1.4, 1.8, k);
+      tgtX = lerp(0.25, 0, k);
+      tgtY = lerp(0.18, 0.05, k);
+      tgtZ = lerp(0.25, 0, k);
+      yaw = lerp(0.15, 0.5, k);
+      pitch = lerp(0, -0.04, k);
+      dx = lerp(0, -0.55, ease(k)); // shift LEFT
+      energy = 0.85;
+      fov = lerp(24, 30, k);
+    } else if (p < 0.78) {
+      // PHASE 6 — FEATURE STUDY: wide three-quarter, drone centered
+      const k = (p - 0.66) / (0.78 - 0.66);
+      camX = lerp(2.4, 1.8, k);
+      camY = lerp(0.45, 0.5, k);
+      camZ = lerp(1.8, 3.2, ease(k));
+      tgtX = lerp(0, 0, k);
+      tgtY = 0;
+      tgtZ = 0;
+      yaw = lerp(0.5, 0.25, k);
+      pitch = lerp(-0.04, -0.02, k);
+      bank = 0;
+      dx = lerp(-0.55, 0, ease(k));
+      energy = 0.8;
+      fov = lerp(30, 32, k);
+    } else if (p < 0.90) {
+      // PHASE 7 — COMMAND TRANSITION: pull WAY back, drone shrinks, drifts up-right
+      const k = (p - 0.78) / (0.90 - 0.78);
+      camX = lerp(1.8, 0.4, k);
+      camY = lerp(0.5, 1.0, ease(k));
+      camZ = lerp(3.2, 6.5, ease(k));
+      yaw = lerp(0.25, 0.05, k);
+      pitch = lerp(-0.02, -0.08, k);
+      scale = lerp(1, 0.55, ease(k));
+      dx = lerp(0, 0.7, k);
+      dy = lerp(0, 0.4, k);
+      energy = lerp(0.8, 0.55, k);
+      fov = lerp(32, 36, k);
     } else {
-      const k = (p - 0.92) / (1 - 0.92);
-      // Lockup
-      camX = lerp(0.8, 0.2, k);
-      camZ = lerp(4.4, 3.4, k);
-      camY = lerp(0.7, 0.45, k);
-      droneRotY = lerp(0.1, -0.05, k);
-      droneScale = lerp(0.78, 1, k);
+      // PHASE 8 — LOCKUP: fly-forward, drone returns to centered hero pose
+      const k = (p - 0.90) / (1.0 - 0.90);
+      camX = lerp(0.4, 0, ease(k));
+      camY = lerp(1.0, 0.4, ease(k));
+      camZ = lerp(6.5, 3.4, ease(k));
+      yaw = lerp(0.05, -0.25, k); // turn to slight 3/4
+      pitch = lerp(-0.08, -0.06, k);
+      scale = lerp(0.55, 1.05, ease(k));
+      dx = lerp(0.7, 0, ease(k));
+      dy = lerp(0.4, 0, ease(k));
+      energy = lerp(0.55, 0.9, k);
+      fov = lerp(36, 30, k);
     }
 
-    desiredCamPos.current.set(camX, camY, camZ);
-    desiredCamTarget.current.set(tgtX, tgtY, tgtZ);
-    desiredDroneRot.current.set(0, droneRotY, 0);
-    desiredDronePos.current.set(droneX, 0, 0);
+    // Idle micro-drift so static moments still feel alive
+    const breathe = Math.sin(t * 0.6) * 0.012;
+    const sway = Math.sin(t * 0.45 + 1.3) * 0.018;
 
-    const lambda = tier === 'low' ? 4.5 : 6.5;
-    camera.position.x = damp(camera.position.x, desiredCamPos.current.x, lambda, dt);
-    camera.position.y = damp(camera.position.y, desiredCamPos.current.y, lambda, dt);
-    camera.position.z = damp(camera.position.z, desiredCamPos.current.z, lambda, dt);
+    working.cam.set(camX + sway, camY + breathe, camZ);
+    working.tgt.set(tgtX, tgtY + breathe * 0.5, tgtZ);
+    working.rot.set(pitch, yaw, bank);
+    working.pos.set(dx, dy, dz);
+    working.scale = scale;
+    working.energy = energy;
+    working.fov = fov;
 
-    targetRef.current.x = damp(targetRef.current.x, desiredCamTarget.current.x, lambda, dt);
-    targetRef.current.y = damp(targetRef.current.y, desiredCamTarget.current.y, lambda, dt);
-    targetRef.current.z = damp(targetRef.current.z, desiredCamTarget.current.z, lambda, dt);
-    camera.lookAt(targetRef.current);
+    // ===== Damp toward target =====
+    const lambda = tier === 'low' ? 5 : 7;
+    camera.position.x = damp(camera.position.x, working.cam.x, lambda, dt);
+    camera.position.y = damp(camera.position.y, working.cam.y, lambda, dt);
+    camera.position.z = damp(camera.position.z, working.cam.z, lambda, dt);
+
+    lookAtRef.current.x = damp(lookAtRef.current.x, working.tgt.x, lambda, dt);
+    lookAtRef.current.y = damp(lookAtRef.current.y, working.tgt.y, lambda, dt);
+    lookAtRef.current.z = damp(lookAtRef.current.z, working.tgt.z, lambda, dt);
+    camera.lookAt(lookAtRef.current);
+
+    if ((camera as THREE.PerspectiveCamera).isPerspectiveCamera) {
+      const persp = camera as THREE.PerspectiveCamera;
+      persp.fov = damp(persp.fov, working.fov, lambda, dt);
+      persp.updateProjectionMatrix();
+    }
 
     if (droneRef.current) {
-      droneRef.current.rotation.y = damp(
-        droneRef.current.rotation.y,
-        desiredDroneRot.current.y,
-        lambda,
-        dt,
-      );
-      droneRef.current.position.x = damp(
-        droneRef.current.position.x,
-        desiredDronePos.current.x,
-        lambda,
-        dt,
-      );
-      const targetScale = droneScale;
-      const cur = droneRef.current.scale.x;
-      const ns = damp(cur, targetScale, lambda, dt);
+      droneRef.current.rotation.x = damp(droneRef.current.rotation.x, working.rot.x, lambda, dt);
+      droneRef.current.rotation.y = damp(droneRef.current.rotation.y, working.rot.y, lambda, dt);
+      droneRef.current.rotation.z = damp(droneRef.current.rotation.z, working.rot.z, lambda, dt);
+      droneRef.current.position.x = damp(droneRef.current.position.x, working.pos.x, lambda, dt);
+      droneRef.current.position.y = damp(droneRef.current.position.y, working.pos.y, lambda, dt);
+      droneRef.current.position.z = damp(droneRef.current.position.z, working.pos.z, lambda, dt);
+      const ns = damp(droneRef.current.scale.x, working.scale, lambda, dt);
       droneRef.current.scale.setScalar(ns);
     }
 
-    // Idle subtle drift on camera so the scene never feels static
-    const t = state.clock.elapsedTime;
-    camera.position.x += Math.sin(t * 0.3) * 0.01;
-    camera.position.y += Math.cos(t * 0.4) * 0.006;
+    energyRef.current = damp(energyRef.current, working.energy, 4, dt);
+    propEnergyRef.current = damp(propEnergyRef.current, working.energy, 3, dt);
   });
 
+  // Pass live energy refs into the model so prop speed reacts
   return (
     <group ref={droneRef}>
-      <DroneModel spinProps={tier !== 'low'} hover={tier !== 'low'} />
+      <DroneModel propEnergyRef={propEnergyRef} hover={tier !== 'low'} />
     </group>
   );
 }
 
-function lerp(a: number, b: number, t: number) {
-  return a + (b - a) * t;
-}
-function ease(t: number) {
-  return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
-}
+function DynamicLighting({ tier }: { tier: ReturnType<typeof useDeviceCapability>['tier'] }) {
+  const keyRef = useRef<THREE.SpotLight>(null!);
+  const rimRef = useRef<THREE.DirectionalLight>(null!);
 
-function StudioLighting({ tier }: { tier: ReturnType<typeof useDeviceCapability>['tier'] }) {
+  useFrame((state) => {
+    const t = state.clock.elapsedTime;
+    if (keyRef.current) {
+      keyRef.current.intensity = 1.2 + Math.sin(t * 0.3) * 0.15;
+    }
+    if (rimRef.current) {
+      rimRef.current.intensity = 1.4 + Math.sin(t * 0.5 + 1) * 0.2;
+    }
+  });
+
   return (
     <>
-      <ambientLight intensity={0.18} color="#1a2030" />
-      {/* Key light */}
+      <ambientLight intensity={0.16} color="#1a2030" />
       <spotLight
-        position={[3, 5, 4]}
+        ref={keyRef}
+        position={[3.2, 5.5, 4]}
         angle={0.55}
-        penumbra={0.85}
-        intensity={1.4}
-        color="#dbe6ff"
+        penumbra={0.92}
+        intensity={1.3}
+        color="#dde7ff"
         castShadow={tier === 'high'}
         shadow-mapSize-width={tier === 'high' ? 1024 : 512}
         shadow-mapSize-height={tier === 'high' ? 1024 : 512}
+        shadow-bias={-0.0005}
       />
-      {/* Blue rim */}
-      <directionalLight position={[-4, 2, -3]} intensity={0.9} color="#1d6fff" />
-      {/* Subtle top accent */}
-      <directionalLight position={[0, 6, 0]} intensity={0.35} color="#00aeef" />
-      {/* Fill */}
-      <pointLight position={[0, -2, 3]} intensity={0.25} color="#2b3a55" />
+      <directionalLight ref={rimRef} position={[-4.5, 1.8, -3]} intensity={1.4} color="#1d6fff" />
+      <directionalLight position={[2, -1, -2]} intensity={0.6} color="#00aeef" />
+      <pointLight position={[0, -1.2, 2.5]} intensity={0.35} color="#1a2540" />
+      {/* Subtle warm kicker on the camera side of the drone */}
+      <pointLight position={[1.5, 1.2, 2]} intensity={0.25} color="#ffb27a" />
     </>
+  );
+}
+
+function GroundPlane() {
+  return (
+    <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.45, 0]} receiveShadow>
+      <planeGeometry args={[60, 60]} />
+      <meshStandardMaterial color="#05070b" roughness={0.95} metalness={0.1} />
+    </mesh>
   );
 }
 
@@ -185,23 +290,28 @@ interface DroneSceneProps {
 
 export function DroneScene({ className }: DroneSceneProps) {
   const cap = useDeviceCapability();
-  const dpr = useMemo<[number, number]>(() => [1, Math.min(cap.dpr, cap.tier === 'low' ? 1.2 : 1.75)], [cap.dpr, cap.tier]);
+  const dpr = useMemo<[number, number]>(
+    () => [1, Math.min(cap.dpr, cap.tier === 'low' ? 1.2 : 1.75)],
+    [cap.dpr, cap.tier],
+  );
   const setReady = useSceneState((s) => s.setReady);
 
   return (
     <div className={className}>
       <Canvas
-        camera={{ position: [0, 0.4, 4.2], fov: 32, near: 0.1, far: 50 }}
+        camera={{ position: [0, 0, 8], fov: 32, near: 0.1, far: 60 }}
         dpr={dpr}
         gl={{
           antialias: true,
           powerPreference: 'high-performance',
           alpha: true,
           stencil: false,
+          toneMapping: THREE.ACESFilmicToneMapping,
         }}
         onCreated={({ gl, scene }) => {
           gl.setClearColor(0x000000, 0);
-          scene.fog = new THREE.Fog(0x030508, 7, 18);
+          scene.fog = new THREE.Fog(0x030508, 6, 22);
+          gl.toneMappingExposure = 1.05;
           setReady(true);
         }}
         shadows={cap.tier === 'high'}
@@ -211,18 +321,33 @@ export function DroneScene({ className }: DroneSceneProps) {
         <AdaptiveEvents />
 
         <Suspense fallback={null}>
-          <StudioLighting tier={cap.tier} />
-          {cap.tier !== 'low' && <Environment preset="warehouse" environmentIntensity={0.18} />}
+          <DynamicLighting tier={cap.tier} />
+          {cap.tier !== 'low' && (
+            <Environment preset="warehouse" environmentIntensity={0.22} />
+          )}
+
+          <GroundPlane />
 
           <Choreography tier={cap.tier} />
 
-          {/* Soft contact shadow under the drone */}
+          {/* Floating dust particles — gives the air "weight" */}
+          {cap.tier !== 'low' && (
+            <Sparkles
+              count={cap.tier === 'high' ? 60 : 30}
+              scale={[6, 3, 6] as unknown as number}
+              size={1.2}
+              speed={0.25}
+              opacity={0.4}
+              color="#9bb6ff"
+            />
+          )}
+
           <ContactShadows
             position={[0, -0.42, 0]}
-            opacity={0.55}
+            opacity={0.7}
             scale={6}
-            blur={2.4}
-            far={2.6}
+            blur={2.8}
+            far={3}
             color="#000000"
             resolution={cap.tier === 'high' ? 512 : 256}
           />

--- a/drom/src/components/three/StaticDronePoster.tsx
+++ b/drom/src/components/three/StaticDronePoster.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+/**
+ * Performant fallback shown when WebGL is unavailable or prefers-reduced-motion is set.
+ * Pure SVG schematic of the drone in three-quarter perspective — no canvas, no animation.
+ */
+export function StaticDronePoster() {
+  return (
+    <div className="absolute inset-0 flex items-center justify-center">
+      <div className="absolute inset-0 grid-overlay-fine opacity-30" aria-hidden />
+      <svg
+        viewBox="0 0 600 480"
+        className="relative w-[88%] max-w-[760px] text-text-primary"
+        aria-label="DROM compact aerial platform — schematic"
+        role="img"
+      >
+        <defs>
+          <linearGradient id="bodyGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stopColor="#1c2330" />
+            <stop offset="1" stopColor="#0a0d13" />
+          </linearGradient>
+          <linearGradient id="armGrad" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0" stopColor="#0e131c" />
+            <stop offset="1" stopColor="#1a2230" />
+          </linearGradient>
+        </defs>
+
+        {/* Center frame */}
+        <rect x="240" y="220" width="120" height="60" rx="2" fill="url(#bodyGrad)" stroke="rgba(80,140,255,0.4)" />
+        {/* Dome */}
+        <ellipse cx="300" cy="200" rx="44" ry="22" fill="#0d1118" stroke="rgba(80,140,255,0.45)" />
+        <line x1="300" y1="220" x2="300" y2="222" stroke="#22262d" strokeWidth="3" />
+        {/* Camera */}
+        <rect x="290" y="265" width="20" height="20" fill="#12161c" stroke="rgba(80,140,255,0.4)" />
+        <circle cx="300" cy="288" r="5" fill="#05080d" stroke="rgba(80,140,255,0.6)" />
+
+        {/* Arms */}
+        {[
+          { x1: 260, y1: 240, x2: 130, y2: 170 },
+          { x1: 340, y1: 240, x2: 470, y2: 170 },
+          { x1: 260, y1: 270, x2: 130, y2: 330 },
+          { x1: 340, y1: 270, x2: 470, y2: 330 },
+        ].map((a, i) => (
+          <line key={i} {...a} stroke="url(#armGrad)" strokeWidth="14" strokeLinecap="square" />
+        ))}
+
+        {/* Motors + props */}
+        {[
+          { x: 130, y: 170 },
+          { x: 470, y: 170 },
+          { x: 130, y: 330 },
+          { x: 470, y: 330 },
+        ].map((m, i) => (
+          <g key={i}>
+            <circle cx={m.x} cy={m.y} r="14" fill="#22262d" stroke="rgba(80,140,255,0.4)" />
+            <circle cx={m.x} cy={m.y} r="9" fill="#6b3a1c" opacity="0.65" />
+            <ellipse cx={m.x} cy={m.y} rx="50" ry="3" fill="#0a0d12" opacity="0.85" />
+            <ellipse cx={m.x} cy={m.y} rx="50" ry="3" fill="#0a0d12" opacity="0.85" transform={`rotate(60 ${m.x} ${m.y})`} />
+            <ellipse cx={m.x} cy={m.y} rx="50" ry="3" fill="#0a0d12" opacity="0.85" transform={`rotate(120 ${m.x} ${m.y})`} />
+          </g>
+        ))}
+
+        {/* Whip antennas */}
+        <line x1="334" y1="222" x2="370" y2="170" stroke="#22262d" strokeWidth="2" />
+        <line x1="266" y1="222" x2="230" y2="170" stroke="#22262d" strokeWidth="2" />
+
+        {/* Schematic labels */}
+        <g fontFamily="ui-monospace, monospace" fontSize="10" fill="#6F7A89" letterSpacing="2">
+          <text x="40" y="170">M-01</text>
+          <text x="540" y="170">M-02</text>
+          <text x="40" y="345">M-03</text>
+          <text x="540" y="345">M-04</text>
+          <text x="270" y="180" fill="#9AA4B2">DOME · ANT</text>
+          <text x="278" y="320" fill="#9AA4B2">OPTIC</text>
+        </g>
+
+        {/* Crosshair */}
+        <g stroke="rgba(80,140,255,0.25)" strokeWidth="1">
+          <line x1="0" y1="240" x2="600" y2="240" />
+          <line x1="300" y1="40" x2="300" y2="440" />
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/drom/src/components/three/sceneState.ts
+++ b/drom/src/components/three/sceneState.ts
@@ -3,11 +3,8 @@
 import { create } from 'zustand';
 
 interface SceneState {
-  /** Smoothed scroll progress through the cinematic, 0..1 */
   progress: number;
-  /** Active phase index 0..7 */
   phase: number;
-  /** True after R3F first frame */
   ready: boolean;
   setProgress: (n: number) => void;
   setPhase: (n: number) => void;
@@ -23,16 +20,19 @@ export const useSceneState = create<SceneState>((set) => ({
   setReady: (v) => set({ ready: v }),
 }));
 
-/** Discrete phase keypoints along the cinematic */
+/**
+ * 8 phases keyed to scroll progress. The label is shown by the bottom HUD strip.
+ * Phase boundaries match the choreography keyframes in DroneScene.tsx.
+ */
 export const PHASES = [
-  { key: 'wake', t: 0.0, label: 'SYSTEM INITIALIZED' },
-  { key: 'reveal', t: 0.14, label: 'PLATFORM PROFILE' },
-  { key: 'inspect', t: 0.30, label: 'INSPECTION ROTATION' },
-  { key: 'spec', t: 0.50, label: 'SPECIFICATION LOCK' },
-  { key: 'features', t: 0.66, label: 'FEATURE MAPPING' },
-  { key: 'command', t: 0.80, label: 'COMMAND INTERFACE' },
-  { key: 'engineering', t: 0.92, label: 'ENGINEERING FOCUS' },
-  { key: 'lockup', t: 1.0, label: 'MISSION READY' },
+  { key: 'wake', t: 0.0, label: 'WAKE' },
+  { key: 'ignition', t: 0.10, label: 'IGNITION' },
+  { key: 'orbit', t: 0.22, label: 'ORBIT · 720°' },
+  { key: 'macro', t: 0.45, label: 'MACRO' },
+  { key: 'spec', t: 0.55, label: 'SPECIFICATION LOCK' },
+  { key: 'features', t: 0.66, label: 'FEATURE STUDY' },
+  { key: 'command', t: 0.78, label: 'COMMAND LAYER' },
+  { key: 'lockup', t: 0.90, label: 'MISSION READY' },
 ] as const;
 
 export type PhaseKey = (typeof PHASES)[number]['key'];

--- a/drom/src/components/three/sceneState.ts
+++ b/drom/src/components/three/sceneState.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { create } from 'zustand';
+
+interface SceneState {
+  /** Smoothed scroll progress through the cinematic, 0..1 */
+  progress: number;
+  /** Active phase index 0..7 */
+  phase: number;
+  /** True after R3F first frame */
+  ready: boolean;
+  setProgress: (n: number) => void;
+  setPhase: (n: number) => void;
+  setReady: (v: boolean) => void;
+}
+
+export const useSceneState = create<SceneState>((set) => ({
+  progress: 0,
+  phase: 0,
+  ready: false,
+  setProgress: (n) => set({ progress: n }),
+  setPhase: (n) => set({ phase: n }),
+  setReady: (v) => set({ ready: v }),
+}));
+
+/** Discrete phase keypoints along the cinematic */
+export const PHASES = [
+  { key: 'wake', t: 0.0, label: 'SYSTEM INITIALIZED' },
+  { key: 'reveal', t: 0.14, label: 'PLATFORM PROFILE' },
+  { key: 'inspect', t: 0.30, label: 'INSPECTION ROTATION' },
+  { key: 'spec', t: 0.50, label: 'SPECIFICATION LOCK' },
+  { key: 'features', t: 0.66, label: 'FEATURE MAPPING' },
+  { key: 'command', t: 0.80, label: 'COMMAND INTERFACE' },
+  { key: 'engineering', t: 0.92, label: 'ENGINEERING FOCUS' },
+  { key: 'lockup', t: 1.0, label: 'MISSION READY' },
+] as const;
+
+export type PhaseKey = (typeof PHASES)[number]['key'];

--- a/drom/src/components/ui/HUDFrame.tsx
+++ b/drom/src/components/ui/HUDFrame.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@/lib/cn';
+
+interface HUDFrameProps {
+  children: React.ReactNode;
+  className?: string;
+  label?: string;
+  status?: string;
+  as?: 'div' | 'section' | 'aside' | 'article';
+}
+
+export function HUDFrame({
+  children,
+  className,
+  label,
+  status,
+  as: Tag = 'div',
+}: HUDFrameProps) {
+  return (
+    <Tag className={cn('panel hud-corner relative p-5 sm:p-6', className)}>
+      {(label || status) && (
+        <div className="mb-4 flex items-center justify-between">
+          {label && <span className="label">{label}</span>}
+          {status && (
+            <span className="micro flex items-center gap-2 text-text-secondary">
+              <span className="h-1.5 w-1.5 rounded-full bg-signal-cyan animate-pulse-dim" />
+              {status}
+            </span>
+          )}
+        </div>
+      )}
+      {children}
+    </Tag>
+  );
+}

--- a/drom/src/components/ui/HUDLine.tsx
+++ b/drom/src/components/ui/HUDLine.tsx
@@ -1,0 +1,30 @@
+import { cn } from '@/lib/cn';
+
+export function HUDLine({
+  className,
+  orientation = 'horizontal',
+}: {
+  className?: string;
+  orientation?: 'horizontal' | 'vertical';
+}) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        'block bg-gradient-to-r from-transparent via-signal-blue/40 to-transparent',
+        orientation === 'horizontal' ? 'h-px w-full' : 'w-px h-full bg-gradient-to-b',
+        className,
+      )}
+    />
+  );
+}
+
+export function HUDDivider({ label }: { label?: string }) {
+  return (
+    <div className="flex items-center gap-4 py-6">
+      <HUDLine className="flex-1" />
+      {label && <span className="label">{label}</span>}
+      <HUDLine className="flex-1" />
+    </div>
+  );
+}

--- a/drom/src/components/ui/Icons.tsx
+++ b/drom/src/components/ui/Icons.tsx
@@ -1,0 +1,88 @@
+// Restrained line icon set for capability cards & UI chrome.
+// 1.25px stroke, 24x24, currentColor.
+
+type IconProps = React.SVGProps<SVGSVGElement> & { size?: number };
+
+const baseProps = (size = 24): React.SVGProps<SVGSVGElement> => ({
+  width: size,
+  height: size,
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.25,
+  strokeLinecap: 'square' as const,
+  strokeLinejoin: 'miter' as const,
+  'aria-hidden': true,
+});
+
+export const IconMobility = ({ size, ...rest }: IconProps) => (
+  <svg {...baseProps(size)} {...rest}>
+    <path d="M3 12h6l2-3 2 6 2-3h6" />
+    <circle cx="12" cy="12" r="9.5" />
+  </svg>
+);
+
+export const IconPrecision = ({ size, ...rest }: IconProps) => (
+  <svg {...baseProps(size)} {...rest}>
+    <circle cx="12" cy="12" r="9.5" />
+    <circle cx="12" cy="12" r="5" />
+    <circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none" />
+    <path d="M12 1.5v3M12 19.5v3M1.5 12h3M19.5 12h3" />
+  </svg>
+);
+
+export const IconIntegration = ({ size, ...rest }: IconProps) => (
+  <svg {...baseProps(size)} {...rest}>
+    <path d="M9 8H6a3 3 0 0 0-3 3v2a3 3 0 0 0 3 3h3" />
+    <path d="M15 8h3a3 3 0 0 1 3 3v2a3 3 0 0 1-3 3h-3" />
+    <path d="M9 12h6" />
+  </svg>
+);
+
+export const IconSecurity = ({ size, ...rest }: IconProps) => (
+  <svg {...baseProps(size)} {...rest}>
+    <path d="M12 2.5l8 3.5v6c0 5-3.5 8.5-8 9.5-4.5-1-8-4.5-8-9.5v-6l8-3.5z" />
+    <path d="M9 12l2 2 4-4" />
+  </svg>
+);
+
+export const IconStructure = ({ size, ...rest }: IconProps) => (
+  <svg {...baseProps(size)} {...rest}>
+    <rect x="3" y="3" width="18" height="18" />
+    <path d="M3 9h18M3 15h18M9 3v18M15 3v18" />
+  </svg>
+);
+
+export const IconControl = ({ size, ...rest }: IconProps) => (
+  <svg {...baseProps(size)} {...rest}>
+    <path d="M3 6h12M19 6h2M3 12h2M9 12h12M3 18h12M19 18h2" />
+    <circle cx="17" cy="6" r="2" />
+    <circle cx="7" cy="12" r="2" />
+    <circle cx="17" cy="18" r="2" />
+  </svg>
+);
+
+export const IconDeploy = ({ size, ...rest }: IconProps) => (
+  <svg {...baseProps(size)} {...rest}>
+    <path d="M12 3v12M7 8l5-5 5 5" />
+    <path d="M3 21h18" />
+  </svg>
+);
+
+export const IconSignal = ({ size, ...rest }: IconProps) => (
+  <svg {...baseProps(size)} {...rest}>
+    <path d="M3 18l4-4M9 18V8M15 18V4M21 18v-6" />
+  </svg>
+);
+
+export const IconArrow = ({ size, ...rest }: IconProps) => (
+  <svg {...baseProps(size)} {...rest}>
+    <path d="M5 12h14M13 6l6 6-6 6" />
+  </svg>
+);
+
+export const IconCorner = ({ size = 12, ...rest }: IconProps) => (
+  <svg {...baseProps(size)} {...rest}>
+    <path d="M2 8V2h6" />
+  </svg>
+);

--- a/drom/src/components/ui/LoadingState.tsx
+++ b/drom/src/components/ui/LoadingState.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+interface LoadingStateProps {
+  progress?: number; // 0..1
+  label?: string;
+}
+
+export function LoadingState({ progress = 0, label = 'LOADING PLATFORM PROFILE' }: LoadingStateProps) {
+  const pct = Math.round(Math.max(0, Math.min(1, progress)) * 100);
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-ink-950 text-text-secondary"
+    >
+      <div className="absolute inset-0 grid-overlay-fine opacity-40" aria-hidden />
+      <div className="relative w-[260px] max-w-[60vw]">
+        <div className="flex items-center justify-between mb-3">
+          <span className="micro text-text-muted">{label}</span>
+          <span className="font-mono text-micro text-text-secondary tabular-nums">
+            {String(pct).padStart(3, '0')}%
+          </span>
+        </div>
+        <div className="relative h-px bg-border-blue/40 overflow-hidden">
+          <div
+            className="absolute inset-y-0 left-0 bg-signal-blue"
+            style={{ width: `${pct}%`, transition: 'width 220ms ease-out' }}
+          />
+        </div>
+        <div className="mt-3 flex items-center gap-2">
+          <span className="h-1.5 w-1.5 rounded-full bg-signal-cyan animate-pulse-dim" />
+          <span className="font-mono text-micro text-text-muted">SYSTEM INITIALIZED · STANDBY</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/drom/src/components/ui/Logo.tsx
+++ b/drom/src/components/ui/Logo.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@/lib/cn';
+
+export function Logo({ className }: { className?: string }) {
+  return (
+    <div className={cn('flex items-center gap-2.5', className)} aria-label="DROM">
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 32 32"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden
+      >
+        <path
+          d="M4 8 L16 22 L28 8"
+          stroke="url(#logoGrad)"
+          strokeWidth="2.4"
+          strokeLinecap="square"
+          strokeLinejoin="miter"
+          fill="none"
+        />
+        <path
+          d="M10 8 L16 16 L22 8"
+          stroke="rgba(244,247,250,0.9)"
+          strokeWidth="1.4"
+          strokeLinecap="square"
+          fill="none"
+        />
+        <defs>
+          <linearGradient id="logoGrad" x1="0" y1="0" x2="32" y2="0" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stopColor="#1D6FFF" />
+            <stop offset="1" stopColor="#00AEEF" />
+          </linearGradient>
+        </defs>
+      </svg>
+      <div className="leading-none">
+        <span className="font-display text-[1.05rem] tracking-[0.18em] font-semibold text-text-primary">
+          DROM
+        </span>
+        <span className="ml-2 font-mono text-micro text-text-muted">/ MDH-X</span>
+      </div>
+    </div>
+  );
+}

--- a/drom/src/components/ui/RadarGraphic.tsx
+++ b/drom/src/components/ui/RadarGraphic.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { cn } from '@/lib/cn';
+
+export function RadarGraphic({ className, size = 220 }: { className?: string; size?: number }) {
+  return (
+    <div
+      aria-hidden
+      className={cn('relative pointer-events-none', className)}
+      style={{ width: size, height: size }}
+    >
+      <svg viewBox="0 0 200 200" className="absolute inset-0 h-full w-full">
+        <defs>
+          <radialGradient id="radarFade" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor="rgba(29,111,255,0.18)" />
+            <stop offset="60%" stopColor="rgba(29,111,255,0.04)" />
+            <stop offset="100%" stopColor="rgba(29,111,255,0)" />
+          </radialGradient>
+          <linearGradient id="sweepGrad" x1="0%" y1="50%" x2="100%" y2="50%">
+            <stop offset="0%" stopColor="rgba(0,174,239,0)" />
+            <stop offset="100%" stopColor="rgba(0,174,239,0.45)" />
+          </linearGradient>
+        </defs>
+        <circle cx="100" cy="100" r="98" fill="url(#radarFade)" />
+        {[20, 45, 70, 95].map((r) => (
+          <circle
+            key={r}
+            cx="100"
+            cy="100"
+            r={r}
+            fill="none"
+            stroke="rgba(80,140,255,0.18)"
+            strokeWidth="0.6"
+          />
+        ))}
+        <line x1="100" y1="2" x2="100" y2="198" stroke="rgba(80,140,255,0.12)" strokeWidth="0.5" />
+        <line x1="2" y1="100" x2="198" y2="100" stroke="rgba(80,140,255,0.12)" strokeWidth="0.5" />
+        <g className="origin-center" style={{ transformOrigin: '100px 100px' }}>
+          <g className="animate-sweep">
+            <path d="M100 100 L100 2 A98 98 0 0 1 196 110 Z" fill="url(#sweepGrad)" opacity="0.55" />
+          </g>
+        </g>
+        <circle cx="100" cy="100" r="2" fill="rgba(0,174,239,0.9)" />
+        <circle cx="60" cy="80" r="1.4" fill="rgba(244,247,250,0.7)" />
+        <circle cx="138" cy="120" r="1.4" fill="rgba(244,247,250,0.55)" />
+        <circle cx="115" cy="55" r="1.2" fill="rgba(244,247,250,0.45)" />
+      </svg>
+    </div>
+  );
+}

--- a/drom/src/components/ui/TechnicalCard.tsx
+++ b/drom/src/components/ui/TechnicalCard.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@/lib/cn';
+
+interface TechnicalCardProps {
+  index?: string;
+  label: string;
+  title: string;
+  body: string;
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+export function TechnicalCard({ index, label, title, body, icon, className }: TechnicalCardProps) {
+  return (
+    <article
+      className={cn(
+        'group panel hud-corner relative p-6 lg:p-7 transition-colors duration-300',
+        'hover:border-signal-blue/60',
+        className,
+      )}
+    >
+      <div className="mb-6 flex items-center justify-between">
+        <span className="micro text-text-muted">{index ?? label}</span>
+        {icon && <span className="text-signal-blue/80">{icon}</span>}
+      </div>
+      <h3 className="font-display text-h5 text-text-primary leading-tight">{title}</h3>
+      <p className="mt-3 text-body text-text-secondary">{body}</p>
+      <span
+        aria-hidden
+        className="absolute left-6 right-6 bottom-0 h-px bg-gradient-to-r from-transparent via-signal-blue/40 to-transparent
+          opacity-0 group-hover:opacity-100 transition-opacity"
+      />
+    </article>
+  );
+}

--- a/drom/src/lib/cn.ts
+++ b/drom/src/lib/cn.ts
@@ -1,0 +1,3 @@
+import clsx, { type ClassValue } from 'clsx';
+
+export const cn = (...inputs: ClassValue[]) => clsx(inputs);

--- a/drom/src/lib/useDeviceCapability.ts
+++ b/drom/src/lib/useDeviceCapability.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export type DeviceCapability = 'high' | 'medium' | 'low' | 'unsupported';
+
+interface CapabilityState {
+  tier: DeviceCapability;
+  webgl: boolean;
+  reducedMotion: boolean;
+  isMobile: boolean;
+  dpr: number;
+}
+
+function detectWebGL(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    const canvas = document.createElement('canvas');
+    return !!(canvas.getContext('webgl2') || canvas.getContext('webgl'));
+  } catch {
+    return false;
+  }
+}
+
+export function useDeviceCapability(): CapabilityState {
+  const [state, setState] = useState<CapabilityState>({
+    tier: 'high',
+    webgl: true,
+    reducedMotion: false,
+    isMobile: false,
+    dpr: 1,
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const webgl = detectWebGL();
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const isMobile = window.matchMedia('(max-width: 767px)').matches;
+    const cores = navigator.hardwareConcurrency ?? 4;
+    const memory = (navigator as Navigator & { deviceMemory?: number }).deviceMemory ?? 4;
+    const dpr = Math.min(window.devicePixelRatio || 1, isMobile ? 1.5 : 2);
+
+    let tier: DeviceCapability = 'high';
+    if (!webgl) tier = 'unsupported';
+    else if (reducedMotion) tier = 'low';
+    else if (isMobile || cores < 4 || memory < 4) tier = 'medium';
+    if (cores <= 2 || memory <= 2) tier = 'low';
+
+    setState({ tier, webgl, reducedMotion, isMobile, dpr });
+  }, []);
+
+  return state;
+}

--- a/drom/src/lib/useReducedMotion.ts
+++ b/drom/src/lib/useReducedMotion.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useReducedMotion(): boolean {
+  const [prefers, setPrefers] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setPrefers(media.matches);
+    const onChange = () => setPrefers(media.matches);
+    media.addEventListener('change', onChange);
+    return () => media.removeEventListener('change', onChange);
+  }, []);
+
+  return prefers;
+}

--- a/drom/tailwind.config.ts
+++ b/drom/tailwind.config.ts
@@ -1,0 +1,99 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        ink: {
+          950: '#030508',
+          900: '#070B12',
+          850: '#0B111A',
+          800: '#101722',
+          700: '#1A2230',
+        },
+        signal: {
+          blue: '#1D6FFF',
+          cyan: '#00AEEF',
+          amber: '#F2B84B',
+        },
+        text: {
+          primary: '#F4F7FA',
+          secondary: '#9AA4B2',
+          muted: '#6F7A89',
+          metallic: '#B9C1CC',
+        },
+        border: {
+          blue: 'rgba(80, 140, 255, 0.28)',
+          subtle: 'rgba(154, 164, 178, 0.10)',
+        },
+      },
+      fontFamily: {
+        display: ['var(--font-display)', 'ui-sans-serif', 'system-ui'],
+        sans: ['var(--font-sans)', 'ui-sans-serif', 'system-ui'],
+        mono: ['var(--font-mono)', 'ui-monospace', 'monospace'],
+      },
+      fontSize: {
+        // Tightly controlled scale
+        'micro': ['0.6875rem', { lineHeight: '1rem', letterSpacing: '0.16em' }],
+        'label': ['0.75rem', { lineHeight: '1rem', letterSpacing: '0.18em' }],
+        'eyebrow': ['0.8125rem', { lineHeight: '1.125rem', letterSpacing: '0.22em' }],
+        'body': ['1rem', { lineHeight: '1.6' }],
+        'lead': ['1.125rem', { lineHeight: '1.65' }],
+        'h6': ['1.125rem', { lineHeight: '1.4', letterSpacing: '-0.005em' }],
+        'h5': ['1.375rem', { lineHeight: '1.3', letterSpacing: '-0.01em' }],
+        'h4': ['1.75rem', { lineHeight: '1.2', letterSpacing: '-0.015em' }],
+        'h3': ['2.25rem', { lineHeight: '1.15', letterSpacing: '-0.02em' }],
+        'h2': ['3rem', { lineHeight: '1.05', letterSpacing: '-0.025em' }],
+        'h1': ['4.25rem', { lineHeight: '1.02', letterSpacing: '-0.03em' }],
+        'display': ['6rem', { lineHeight: '0.96', letterSpacing: '-0.035em' }],
+      },
+      letterSpacing: {
+        widest: '0.22em',
+      },
+      maxWidth: {
+        prose: '64ch',
+        shell: '1440px',
+      },
+      boxShadow: {
+        'panel': '0 1px 0 0 rgba(255,255,255,0.04) inset, 0 0 0 1px rgba(80,140,255,0.10), 0 30px 80px -40px rgba(0,0,0,0.8)',
+        'glow-blue': '0 0 0 1px rgba(29,111,255,0.35), 0 0 40px -10px rgba(29,111,255,0.45)',
+      },
+      backgroundImage: {
+        'grid-fine':
+          'linear-gradient(to right, rgba(80,140,255,0.06) 1px, transparent 1px), linear-gradient(to bottom, rgba(80,140,255,0.06) 1px, transparent 1px)',
+        'grid-coarse':
+          'linear-gradient(to right, rgba(80,140,255,0.10) 1px, transparent 1px), linear-gradient(to bottom, rgba(80,140,255,0.10) 1px, transparent 1px)',
+        'radial-fade':
+          'radial-gradient(ellipse at center, rgba(29,111,255,0.10), transparent 60%)',
+      },
+      keyframes: {
+        sweep: {
+          '0%': { transform: 'rotate(0deg)' },
+          '100%': { transform: 'rotate(360deg)' },
+        },
+        pulseDim: {
+          '0%, 100%': { opacity: '0.35' },
+          '50%': { opacity: '0.9' },
+        },
+        scanline: {
+          '0%': { transform: 'translateY(-100%)' },
+          '100%': { transform: 'translateY(100%)' },
+        },
+        fadeUp: {
+          '0%': { opacity: '0', transform: 'translateY(8px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+      },
+      animation: {
+        sweep: 'sweep 6s linear infinite',
+        'pulse-dim': 'pulseDim 2.4s ease-in-out infinite',
+        scanline: 'scanline 4s linear infinite',
+        'fade-up': 'fadeUp 0.6s ease-out both',
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/drom/tsconfig.json
+++ b/drom/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Adds a complete, production-grade premium product website for **DROM**, a compact aerial platform for defense and security applications. Lives at `drom/` so the existing Vue Geoguess project is untouched.

The cinematic hero is a single 7VH pinned `ScrollTrigger` stage that drives a procedural Three.js drone through 7 phases — system wake → hero reveal → inspection orbit → spec lock → feature mapping → command interface → final lockup — giving the impression of a long frame sequence while only running real-time interpolation. **No 10,000-frame image dump, no GLB to download.**

### Stack

- Next.js 14 App Router · React 18 · TypeScript
- Tailwind with a dark institutional design system (`#030508`, `#1D6FFF`, `#00AEEF`)
- `three`, `@react-three/fiber`, `@react-three/drei`
- `gsap` + `ScrollTrigger`, `@studio-freight/lenis`, `zustand`
- Sora (display) · Inter (body) · IBM Plex Mono (technical labels)

### What's in it

- **Procedural drone** built from Three.js primitives (frame, arms, motors with torus coils, three-blade props, top dome antenna, front camera turret, whip antennas, landing skids) — matches the look of the reference photos without shipping any GLB/KTX2 assets
- **7 cinematic phases** keyed to scroll progress 0..1 with frame-rate-independent damping for camera, drone rotation, position, and scale
- **Phase-driven copy crossfade**: HeroCopy, InspectionCopy, SpecLock, FeatureCallouts, CommandLayer, LockupCopy
- **Always-on HUD chrome**: phase indicator, scrub bar, telemetry chips, scanline, crosshair
- **All 10 sections** from the brief (Hero/Cinematic, Platform Overview, Specifications, Capabilities, Command Interface concept, Engineering Focus, Deployment Context, Technical Brief CTA, Footer)
- **Reduced-motion + WebGL-absent** path swaps the canvas for an SVG schematic poster, disables Lenis, collapses the pinned 7VH stage to `auto`
- **Adaptive performance**: device tier detection, conditional shadows/environment, capped DPR, scrub adjusted on low tier
- **Accessibility**: skip-to-content link, semantic landmarks, focus rings, `aria-*` on the mobile nav, `<noscript>` banner, color is never the only signal

### Content governance

Only the verified specs from the brief are surfaced (`395 × 395 × 190 mm`, `1180 g`). Flight time, range, speed, payload, encryption, autonomy, AI, and environmental ratings are intentionally omitted. The command interface is explicitly framed as a "conceptual UI" with `SIMULATED UI CONCEPT` labels.

### Build output

```
Route (app)                              Size     First Load JS
┌ ○ /                                    55.2 kB         148 kB
├ ○ /_not-found                          872 B          93.1 kB
└ ○ /icon.svg                            0 B                0 B
+ First Load JS shared by all            92.3 kB
```

148 kB First Load for a fully WebGL site.

### Notes for review

- A real GLB was not supplied. When one is available, drop it at `public/models/drom.glb` and replace the geometry inside `DroneModel.tsx` with `useGLTF` — the choreography rig in `DroneScene.tsx` will keep working unchanged.
- I placed `PlatformOverview` after the cinematic stage rather than between hero and inspection, so the cinematic flows as a single uninterrupted intro experience. Easy to reorder in `src/app/page.tsx`.

## Test plan

- [ ] `cd drom && npm install && npm run build` succeeds (verified locally — clean build, no warnings)
- [ ] `npm run start` and load `http://localhost:3000` — hero renders, cinematic scrubs through 7 phases as you scroll
- [ ] Verify reduced-motion: `chrome://settings` → Reduce motion → SVG schematic poster appears, no pin
- [ ] Verify mobile: Responsive Mode → narrow viewport, mobile nav opens, feature callouts collapse to a stacked list
- [ ] Disable JS in DevTools → noscript banner appears, anchored sections still navigable
- [ ] Tab through the page — focus rings visible, skip link reaches `#overview`
- [ ] Lighthouse desktop (manual) — verify performance/a11y/SEO ≥ 90

https://claude.ai/code/session_01Wk31ybTVcUqV999oZ1mbuq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk31ybTVcUqV999oZ1mbuq)_